### PR TITLE
fix: drop math.random() from storybook children fn

### DIFF
--- a/src/lib/storybookUtils.tsx
+++ b/src/lib/storybookUtils.tsx
@@ -1,7 +1,7 @@
 function generateDarkPastelColor(index: number) {
   const hue = (index * 137) % 360
-  const saturation = 40 + Math.random() * 20
-  const lightness = 30 + Math.random() * 10
+  const saturation = 30
+  const lightness = 45
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`
 }
 


### PR DESCRIPTION
Make it pure