### PR TITLE
feat: Pass the original value to the onChange callback for combobox

### DIFF
--- a/src/components/Combobox/index.stories.tsx
+++ b/src/components/Combobox/index.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof Combobox>
 
 // Example data
 const frameworks = [
-  { value: 'Next.js', label: 'Next.js' },
+  { value: 'next.js', label: 'Next.js' },
   { value: 'sveltekit', label: 'SvelteKit' },
   { value: 'nuxt.js', label: 'Nuxt.js' },
   { value: 'remix', label: 'Remix', disabled: true },
@@ -23,7 +23,7 @@ const groupedFrameworks = [
   {
     label: 'React Based',
     options: [
-      { value: 'Next.js', label: 'Next.js' },
+      { value: 'next.js', label: 'Next.js' },
       { value: 'remix', label: 'Remix', disabled: true },
       { value: 'gatsby', label: 'Gatsby' },
     ],

--- a/src/components/Combobox/index.tsx
+++ b/src/components/Combobox/index.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react'
-import {Virtuoso} from 'react-virtuoso'
-import {cn} from '@/lib/utils'
-import {Button, ButtonProps} from '@/components/Button'
-import {Command, CommandGroup, CommandInput, CommandItem, CommandList,} from '@/components/Command'
-import {Popover, PopoverContent, PopoverTrigger} from '@/components/Popover'
-import {Icon} from '../Icon' // I don't like that these aren't based on REM but I'm not sure how to fix it right now
+import { Virtuoso } from 'react-virtuoso'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/Button'
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/Command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/Popover'
+import { ButtonProps } from '@/components/Button'
+import { Icon } from '../Icon'
 
 // I don't like that these aren't based on REM but I'm not sure how to fix it right now
 const COMBOBOX_CONFIG = {


### PR DESCRIPTION
This is a[ known issue ](https://github.com/shadcn-ui/ui/issues/889)with shadcn 

The fix is to manually pass through `option.value` (which retains correct casing) rather than using the underlying `currentValue` passed by the library to the callback

Below is a before and after logging the value received by the callback
![CleanShot 2025-01-06 at 10 06 03@2x](https://github.com/user-attachments/assets/b1af9d90-2edc-458a-8172-7738f990f2af)
