### PR TITLE
fix: overflow x scroll table

### DIFF
--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Table> = {
   component: Table,
   decorators: [
     (Story) => (
-      <div className="mx-auto my-10 max-w-screen-lg">
+      <div className="mx-auto my-10">
         <Story />
       </div>
     ),
@@ -156,4 +156,12 @@ export const Grouped: StoryObj<GroupedTableProps> = {
     ),
   },
   render: (args) => <GroupedTableWithState {...args} />,
+}
+
+export const WithLotsOfColumns: StoryObj<ListTableProps> = {
+  args: {
+    ...defaultArgs,
+    columns: defaultArgs.columns.concat(defaultArgs.columns),
+  },
+  render: (args) => <TableWithState {...args} />,
 }

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -131,7 +131,7 @@ export function Table<T extends object>({
         } as React.CSSProperties
       }
       ref={tableRef}
-      className="relative grid w-full caption-bottom overflow-hidden rounded-lg border text-sm [border-collapse:separate] [border-spacing:0] [grid-template-columns:var(--grid-template-columns)]"
+      className="relative grid w-full caption-bottom overflow-y-hidden overflow-x-scroll rounded-lg border text-sm [border-collapse:separate] [border-spacing:0] [grid-template-columns:var(--grid-template-columns)]"
     >
       <thead className="grid h-14 [grid-column:1/-1] [grid-template-columns:subgrid]">
         <tr className="table-header grid border-b [grid-column:1/-1] [grid-template-columns:subgrid]">


### PR DESCRIPTION
This is a short term fix to enable scrolling horizontally over table columns on small viewports. Eventually, we'll implement something like https://codepen.io/team/css-tricks/pen/wXgJww?editors=1100 or one of the other responsive table recommendations at https://bradfrost.github.io/this-is-responsive/patterns.html#:~:text=Full%2Dscreen%20iFrame-,Tables,-Responsive%20Table