### PR TITLE
fix: CLI wizard layout

### DIFF
--- a/src/components/__beta__/CLIWizard/index.tsx
+++ b/src/components/__beta__/CLIWizard/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Check, ChevronRight, ChevronUp } from 'lucide-react'
+import { Check, ChevronUp } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { Text } from '../../Text'
@@ -98,25 +98,25 @@ export function CLIWizard({
         }
       >
         <div className="flex items-center justify-between">
+          <Heading variant="md" as="h2">
+            Getting Started
+          </Heading>
           <Stack direction="horizontal" align="center" gap={3}>
-            <Heading variant="md" as="h2">
-              Getting Started
-            </Heading>
             <Text muted variant="xs">
-              {completedSteps.length} / {steps.length}
+              {completedSteps.length} / {steps.length} steps completed
             </Text>
+            <motion.div
+              initial="up"
+              animate={isCollapsed ? 'down' : 'up'}
+              variants={chevronVariants}
+              transition={{
+                duration: 0.2,
+                ease: [0.215, 0.61, 0.355, 1],
+              }}
+            >
+              <ChevronUp className="h-4 w-4 text-zinc-400" />
+            </motion.div>
           </Stack>
-          <motion.div
-            initial="up"
-            animate={isCollapsed ? 'down' : 'up'}
-            variants={chevronVariants}
-            transition={{
-              duration: 0.2,
-              ease: [0.215, 0.61, 0.355, 1],
-            }}
-          >
-            <ChevronUp className="h-4 w-4 text-zinc-400" />
-          </motion.div>
         </div>
       </button>
 
@@ -257,9 +257,6 @@ function SidebarSteps({
                   >
                     <div className="flex h-6 items-center justify-between">
                       <Heading variant="xs">{step.title}</Heading>
-                      {active && (
-                        <ChevronRight className="h-4 w-4 text-zinc-400" />
-                      )}
                     </div>
                   </button>
 


### PR DESCRIPTION

![CleanShot 2025-02-03 at 13 51 09](https://github.com/user-attachments/assets/8be32be5-5390-4e34-935d-f981b64acc79)


- Move steps label for better visual balance
- Remove unnecessary right arrow from sidebar