### PR TITLE
fix: use proper colors for pr link

### DIFF
--- a/src/components/PullRequestLink/index.tsx
+++ b/src/components/PullRequestLink/index.tsx
@@ -36,7 +36,7 @@ export function PullRequestLink({
         <PullRequestStatusIcon status={status} />
       </span>
       <span className="text-muted-foreground text-xs font-semibold">
-        {`PR #${num}`}
+        {`#${num}`}
       </span>
     </a>
   )


### PR DESCRIPTION
I also felt we needed the word "PR" to mirror github, but also because it looked a little spare without (see below)

![CleanShot 2025-02-19 at 09 24 57@2x](https://github.com/user-attachments/assets/414b43a3-591f-48c1-b143-e0fb2105a886)
