### PR TITLE
fix: allow one card child

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -118,7 +118,7 @@ const CardFooter: FC<CardFooterProps> = ({ content, className }) => (
 CardFooter.displayName = 'CardFooter'
 
 type CardProps = {
-  children: ReactNode
+  children: ReactNode | ReactNode[]
   onClick?: () => void
   href?: string
   className?: string


### PR DESCRIPTION
Trying to make some marketing card layouts and getting this error
![Screenshot 2025-03-11 at 1 26 17 PM](https://github.com/user-attachments/assets/e803beae-cfed-4b0d-bfc7-725fdfab1f1b)

Let me know if I missed a reason this needs to be an array of ReactNodes vs allowing for both