### PR TITLE
fix: flex issue

### DIFF
--- a/src/components/Navbar/Slim.tsx
+++ b/src/components/Navbar/Slim.tsx
@@ -182,7 +182,7 @@ export const Slim = ({
           onClick={onCollapse}
         />
       </div>
-      <div className="flex-1">{children}</div>
+      <div className="min-w-0 flex-1">{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
Fixes an issue with the sandbox - the nav children (e.g the content) were not constrained via min-width:

> min-width in a flex context: While the default min-width value is 0 (zero), for flex items it is auto. This can make block elements take up much more space than desired, resulting in overflow.

