### PR TITLE
feat: export component prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "chromatic": "chromatic",
-    "lint": "pnpm eslint",
-    "lint:fix": "pnpm eslint --fix",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
     "test": "vitest"
   },
   "author": "Speakeasy",

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -33,7 +33,7 @@ const alertVariants = cva<{
   }
 )
 
-type AlertProps = {
+export type AlertProps = {
   variant: NonNullable<VariantProps<typeof alertVariants>['variant']>
   children: React.ReactNode
   inline?: boolean

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -13,7 +13,7 @@ type BadgeVariants =
 
 type BadgeSizes = 'xs' | 'sm' | 'md' | 'lg'
 
-interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   as?: React.ElementType
   variant?: BadgeVariants

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import { isValidElement, ReactElement, ReactNode, Children } from 'react'
 
-interface BreadcrumbProps {
+export interface BreadcrumbProps {
   children: ReactElement<typeof BreadcrumbItem>[]
   separator?: ReactNode
   className?: string

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -117,7 +117,7 @@ const CardFooter: FC<CardFooterProps> = ({ content, className }) => (
 )
 CardFooter.displayName = 'CardFooter'
 
-type CardProps = {
+export type CardProps = {
   children: ReactNode | ReactNode[]
   onClick?: () => void
   href?: string

--- a/src/components/CodeSnippet/index.tsx
+++ b/src/components/CodeSnippet/index.tsx
@@ -10,7 +10,7 @@ import { Icon } from '../Icon'
 import { useConfig } from '@/hooks/useConfig'
 import { highlightCode, getCodeHandlers } from '@/lib/codeUtils'
 
-interface CodeSnippetProps {
+export interface CodeSnippetProps {
   /**
    * The code to display.
    */

--- a/src/components/Combobox/index.tsx
+++ b/src/components/Combobox/index.tsx
@@ -54,7 +54,7 @@ interface ComboboxBaseProps<T extends string = string> {
   iconOnly?: boolean
 }
 
-type ComboboxProps<T extends string = string> = ComboboxBaseProps<T> &
+export type ComboboxProps<T extends string = string> = ComboboxBaseProps<T> &
   ComboboxDataProps<T>
 
 export function Combobox<T extends string = string>({

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -3,7 +3,7 @@ import { cn, getResponsiveClasses } from '@/lib/utils'
 import { Padding, ResponsiveValue } from '@/types'
 import { ReactNode } from 'react'
 
-interface ContainerProps {
+export interface ContainerProps {
   children: ReactNode
   flex?: boolean
   padding?: ResponsiveValue<Padding>

--- a/src/components/DragNDrop/DragNDropArea.tsx
+++ b/src/components/DragNDrop/DragNDropArea.tsx
@@ -1,7 +1,7 @@
 import { CollisionDetection, DndContext, Modifier } from '@dnd-kit/core'
 import { restrictToWindowEdges } from '@dnd-kit/modifiers'
 
-interface DragNDropAreaProps {
+export interface DragNDropAreaProps {
   children: React.ReactNode
 
   modifiers?: Modifier[]

--- a/src/components/DragNDrop/Draggable.tsx
+++ b/src/components/DragNDrop/Draggable.tsx
@@ -19,7 +19,7 @@ export interface DraggableChildrenProps {
   node: MutableRefObject<HTMLElement | null> | null
 }
 
-interface DraggableProps<TData> extends DndMonitorListener {
+export interface DraggableProps<TData> extends DndMonitorListener {
   /**
    * The children to render.
    *

--- a/src/components/DragNDrop/Droppable.tsx
+++ b/src/components/DragNDrop/Droppable.tsx
@@ -9,7 +9,7 @@ interface DroppableData {
   node: MutableRefObject<HTMLElement | null>
 }
 
-interface DroppableProps<TData extends Record<string, unknown>> {
+export interface DroppableProps<TData extends Record<string, unknown>> {
   /**
    * A function that returns a React node or a React node.
    * If a function is provided, it will be called with the droppable data.

--- a/src/components/ExternalPill/index.tsx
+++ b/src/components/ExternalPill/index.tsx
@@ -14,7 +14,7 @@ type AllExternalIcons =
   | 'terraform'
 const supportedExternals = ['github', 'npm', 'rubygems']
 
-interface ExternalPillProps {
+export interface ExternalPillProps {
   href: string
   icon: AllExternalIcons
   text: React.ReactNode

--- a/src/components/GradientCircle/index.tsx
+++ b/src/components/GradientCircle/index.tsx
@@ -3,7 +3,7 @@ import { Size } from '@/types'
 import './gradientCircle.css'
 import { useMemo } from 'react'
 
-interface GradientCircleProps {
+export interface GradientCircleProps {
   name: string
   size?: Size
   transition?: boolean

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -7,7 +7,7 @@ import { cn, getResponsiveClasses } from '@/lib/utils'
 import { Columns, Gap, Padding, ResponsiveValue } from '@/types'
 import { isValidElement, ReactElement } from 'react'
 
-interface GridProps {
+export interface GridProps {
   /**
    * The number of columns in the grid.
    * @default 1

--- a/src/components/HighlightedText/index.tsx
+++ b/src/components/HighlightedText/index.tsx
@@ -2,7 +2,8 @@ import { cn } from '@/lib/utils'
 import { motion, useInView } from 'framer-motion'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-interface HighlightedTextProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface HighlightedTextProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
   children: string
   color?: Color
   muted?: boolean

--- a/src/components/KeyHint/index.tsx
+++ b/src/components/KeyHint/index.tsx
@@ -18,13 +18,12 @@ const modifierMap: Record<Modifier, string> = {
   esc: 'Esc',
 }
 
-export function Key({
-  value,
-  className,
-}: {
+export interface KeyProps {
   value: string
   className?: string
-}) {
+}
+
+export function Key({ value, className }: KeyProps) {
   return (
     <span
       className={cn(
@@ -67,7 +66,7 @@ function KeyHintKeys({ modifiers, keys }: KeyHintItemProps) {
   )
 }
 
-interface KeyHintProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface KeyHintProps extends React.HTMLAttributes<HTMLDivElement> {
   modifiers: Modifier[]
   keys: string[]
   actionText: string

--- a/src/components/LanguageIndicator/index.tsx
+++ b/src/components/LanguageIndicator/index.tsx
@@ -2,7 +2,7 @@
 import { cn } from '@/lib/utils'
 import { SupportedLanguage } from '@/types'
 
-interface LanguageIndicatorProps {
+export interface LanguageIndicatorProps {
   language: SupportedLanguage
   className?: string
   indicatorOnly?: boolean

--- a/src/components/LoggedInUserMenu/index.tsx
+++ b/src/components/LoggedInUserMenu/index.tsx
@@ -12,7 +12,7 @@ import { UserAvatarProps } from '../UserAvatar'
 import React, { Children, Fragment, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
-interface LoggedInUserProps extends UserAvatarProps {
+export interface LoggedInUserProps extends UserAvatarProps {
   email: string
   children?: ReactNode | ReactNode[]
   onSignOut: () => void

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -2,7 +2,7 @@ import * as svgs from './svgs'
 
 type LogoVariant = 'wordmark' | 'icon'
 
-interface LogoProps extends React.SVGProps<SVGSVGElement> {
+export interface LogoProps extends React.SVGProps<SVGSVGElement> {
   variant: LogoVariant
   muted?: boolean
 }

--- a/src/components/Navbar/index.ts
+++ b/src/components/Navbar/index.ts
@@ -1,4 +1,4 @@
-import { Slim } from './Slim'
+import { Slim, SlimProps } from './Slim'
 
 const Navbar = Object.assign(Slim, {
   /**
@@ -9,4 +9,5 @@ const Navbar = Object.assign(Slim, {
   // TODO: Add the full Navbar component here once we have ported across from the registry
 })
 
-export { Navbar }
+export { Navbar, type SlimProps as NavbarProps }
+export { type NavItem } from './Slim'

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 import useTailwindBreakpoint from '@/hooks/useTailwindBreakpoint'
 import { Link, LinkProps } from '../Link'
 
-interface PageHeaderProps extends PropsWithChildren {
+export interface PageHeaderProps extends PropsWithChildren {
   className?: string
 }
 

--- a/src/components/PromptInput/index.tsx
+++ b/src/components/PromptInput/index.tsx
@@ -22,7 +22,7 @@ export interface Attachment {
   onRemove?: (id: string) => void
 }
 
-interface PromptInputProps {
+export interface PromptInputProps {
   prompt?: string
   placeholder: string
   onChange: (prompt: string) => void

--- a/src/components/PullRequestLink/index.tsx
+++ b/src/components/PullRequestLink/index.tsx
@@ -5,7 +5,7 @@ import { GitPullRequest, GitPullRequestClosed, Merge } from 'lucide-react'
 
 type Status = 'open' | 'closed' | 'merged'
 
-interface PullRequestLinkProps {
+export interface PullRequestLinkProps {
   href: string
   prNumber?: number
   status?: Status

--- a/src/components/Separator/index.tsx
+++ b/src/components/Separator/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import { Orientation } from '@/types'
 
-interface SeparatorProps {
+export interface SeparatorProps {
   orientation?: Orientation
   className?: string
 }

--- a/src/components/Stack/index.tsx
+++ b/src/components/Stack/index.tsx
@@ -26,7 +26,7 @@ type TailwindAlign =
   | 'items-stretch'
 type TailwindDirection = 'flex-row' | 'flex-col'
 
-interface StackProps {
+export interface StackProps {
   children: React.ReactNode
 
   /** Specify the orientation for the stack container */

--- a/src/components/Subnav/index.tsx
+++ b/src/components/Subnav/index.tsx
@@ -18,7 +18,7 @@ export interface SubnavItem {
   [key: string]: unknown
 }
 
-interface SubnavProps {
+export interface SubnavProps {
   items: SubnavItem[]
   renderItem: (item: SubnavItem) => React.ReactNode
   className?: string
@@ -65,11 +65,7 @@ const useDebounce = (callback: () => void, delay: number) => {
   }, [callback, delay])
 }
 
-export function Subnav({
-  items,
-  renderItem,
-  className,
-}: SubnavProps & { className?: string }) {
+export function Subnav({ items, renderItem, className }: SubnavProps) {
   const [activeItem, setActiveItem] = useState<string | null>(
     items.find((item) => item.active)?.href ?? null
   )

--- a/src/components/Wizard/index.tsx
+++ b/src/components/Wizard/index.tsx
@@ -4,7 +4,7 @@ import { CodeSnippet, Heading, Text } from '@/index'
 import { useMemo } from 'react'
 import { WizardStep } from './types'
 
-interface WizardProps {
+export interface WizardProps {
   /**
    * The steps to display in the wizard
    */

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -12,7 +12,7 @@ export const ConfigContext = createContext<ConfigContextType | undefined>(
   undefined
 )
 
-interface MoonshineConfigProviderProps extends ConfigContextType {
+export interface MoonshineConfigProviderProps extends ConfigContextType {
   children: React.ReactNode
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,58 @@
 import './global.css'
 
 export { isGroupOf } from '@/lib/typeUtils'
-export { Grid } from '@/components/Grid'
-export { Stack } from '@/components/Stack'
+export { Grid, type GridProps } from '@/components/Grid'
+export { Stack, type StackProps } from '@/components/Stack'
 export { Button, type ButtonProps } from '@/components/Button'
-export { Card } from '@/components/Card'
-export { Icon } from '@/components/Icon'
+export { Card, type CardProps } from '@/components/Card'
+export { Icon, type IconProps } from '@/components/Icon'
 export { isIconName } from '@/components/Icon/isIconName'
 export { type IconName } from '@/components/Icon/names'
-export { Separator } from '@/components/Separator'
-export { Badge } from '@/components/Badge'
-export { Heading } from '@/components/Heading'
-export { Text } from '@/components/Text'
+export { Separator, type SeparatorProps } from '@/components/Separator'
+export { Badge, type BadgeProps } from '@/components/Badge'
+export { Heading, type HeadingProps } from '@/components/Heading'
+export { Text, type TextProps } from '@/components/Text'
 export { Score, type ScoreValue } from '@/components/Score'
-export { Logo } from '@/components/Logo'
-export { Container } from '@/components/Container'
-export { Combobox } from '@/components/Combobox'
-export { TargetLanguageIcon } from '@/components/TargetLanguageIcon'
-export { UserAvatar } from '@/components/UserAvatar'
-export { Subnav, type SubnavItem } from '@/components/Subnav'
-export { Breadcrumb } from '@/components/Breadcrumb'
-export { CodeSnippet } from '@/components/CodeSnippet'
-export { LoggedInUserMenu } from '@/components/LoggedInUserMenu'
-export { PromptInput } from '@/components/PromptInput'
+export { Logo, type LogoProps } from '@/components/Logo'
+export { Container, type ContainerProps } from '@/components/Container'
+export { Combobox, type ComboboxProps } from '@/components/Combobox'
+export {
+  TargetLanguageIcon,
+  type TargetLanguageIconProps,
+} from '@/components/TargetLanguageIcon'
+export { UserAvatar, type UserAvatarProps } from '@/components/UserAvatar'
+export { Subnav, type SubnavItem, type SubnavProps } from '@/components/Subnav'
+export { Breadcrumb, type BreadcrumbProps } from '@/components/Breadcrumb'
+export { CodeSnippet, type CodeSnippetProps } from '@/components/CodeSnippet'
+export {
+  LoggedInUserMenu,
+  type LoggedInUserProps,
+} from '@/components/LoggedInUserMenu'
+export {
+  PromptInput,
+  type PromptInputProps,
+  type Suggestion,
+  type Attachment,
+} from '@/components/PromptInput'
 export {
   WorkspaceSelector,
   type Org,
   type Workspace,
+  type WorkspaceSelectorProps,
 } from '@/components/WorkspaceSelector'
-export { Wizard } from '@/components/Wizard'
+export { Wizard, type WizardProps } from '@/components/Wizard'
 export { type WizardStep, type WizardCommand } from '@/components/Wizard/types'
-export { MoonshineConfigProvider } from '@/context/ConfigContext'
+export {
+  MoonshineConfigProvider,
+  type MoonshineConfigProviderProps,
+} from '@/context/ConfigContext'
 export { useConfig as useMoonshineConfig } from '@/hooks/useConfig'
-export { GradientCircle } from '@/components/GradientCircle'
-export { Alert } from '@/components/Alert'
-export { Tabs, type TabProps, type TabsProps } from '@/components/Tabs'
+export {
+  GradientCircle,
+  type GradientCircleProps,
+} from '@/components/GradientCircle'
+export { Alert, type AlertProps } from '@/components/Alert'
+export { Tabs, type TabProps } from '@/components/Tabs'
 export {
   Table,
   type TableProps,
@@ -47,11 +65,17 @@ export {
   supportedLanguages,
   isSupportedLanguage,
 } from '@/types'
-export { PageHeader } from '@/components/PageHeader'
+export { PageHeader, type PageHeaderProps } from '@/components/PageHeader'
 export { default as useTailwindBreakpoint } from '@/hooks/useTailwindBreakpoint'
-export { ExternalPill } from '@/components/ExternalPill'
-export { LanguageIndicator } from '@/components/LanguageIndicator'
-export { PullRequestLink } from '@/components/PullRequestLink'
+export { ExternalPill, type ExternalPillProps } from '@/components/ExternalPill'
+export {
+  LanguageIndicator,
+  type LanguageIndicatorProps,
+} from '@/components/LanguageIndicator'
+export {
+  PullRequestLink,
+  type PullRequestLinkProps,
+} from '@/components/PullRequestLink'
 export {
   Select,
   SelectGroup,
@@ -79,19 +103,46 @@ export {
 export { Facepile, type FacepileProps } from '@/components/Facepile'
 export { Link, type LinkProps } from '@/components/Link'
 export { Dialog } from '@/components/Dialog'
-export { Navbar } from '@/components/Navbar'
+export { Navbar, type NavbarProps, type NavItem } from '@/components/Navbar'
 export { Switch, type SwitchProps } from '@/components/Switch'
 
-export { ActionBar } from '@/components/ActionBar'
-export { Key, KeyHint } from '@/components/KeyHint'
-export { HighlightedText } from '@/components/HighlightedText'
-export { DragNDropArea } from '@/components/DragNDrop/DragNDropArea'
+export { ActionBar, type ActionBarProps } from '@/components/ActionBar'
+export {
+  Key,
+  type KeyProps,
+  KeyHint,
+  type KeyHintProps,
+} from '@/components/KeyHint'
+export {
+  HighlightedText,
+  type HighlightedTextProps,
+} from '@/components/HighlightedText'
+export {
+  DragNDropArea,
+  type DragNDropAreaProps,
+} from '@/components/DragNDrop/DragNDropArea'
 export { DragOverlay } from '@/components/DragNDrop/DragOverlay'
-export { Draggable } from '@/components/DragNDrop/Draggable'
-export { Droppable } from '@/components/DragNDrop/Droppable'
-export { ResizablePanel } from '@/components/ResizablePanel'
-export { CodePlayground } from '@/components/CodePlayground'
-export { CodeEditor } from '@/components/CodeEditorLayout'
+export {
+  Draggable,
+  type DraggableProps,
+} from '@/components/DragNDrop/Draggable'
+export {
+  Droppable,
+  type DroppableProps,
+} from '@/components/DragNDrop/Droppable'
+export {
+  ResizablePanel,
+  type ResizablePanelProps,
+} from '@/components/ResizablePanel'
+export {
+  CodePlayground,
+  type CodePlaygroundProps,
+  type CodePlaygroundSnippets,
+} from '@/components/CodePlayground'
+export {
+  CodeEditor,
+  type CodeEditorLayoutProps,
+} from '@/components/CodeEditorLayout'
 export {
   Command,
   CommandGroup,


### PR DESCRIPTION
This PR exports most component prop types so they can be used in consuming packages. Currently, we have to do wonky+questionable workarounds to import them, since Moonshine uses the `exports` field in package.json. The intention of using `exports` is specifically to lock down exports so you can't reach into a package and import internal details, (an intention I agree with), e.g. `import { Foo } from '@speakeasy-api/moonshine/dist/foo';` fails

Turns out, there is one weird workaround that I'm guessing is Vite specific though that allows us to do this, as you can see in Sandbox 😬:

https://github.com/speakeasy-api/speakeasy-registry/blob/6dc2308e8eafdefe53af087696e672412d70664c/web/packages/sandbox/src/Sandbox.tsx#L6

There are a few components that are direct or shimmed exports from Radix and friends that I didn't grab types for, and there are likely sub types that aren't exported. I figure this is a good start though.