### PR TITLE
fix: move error state outside of snippets

### DIFF
--- a/src/components/CodePlayground/index.stories.tsx
+++ b/src/components/CodePlayground/index.stories.tsx
@@ -226,20 +226,20 @@ export const ErrorState: Story = {
   ...Default,
   args: {
     ...Default.args,
+    error: (
+      <div className="flex flex-col gap-2 p-4">
+        <h3 className="text-base font-semibold text-rose-400">
+          Could not generate
+        </h3>
+        <p className="text-body-muted text-sm">
+          This might be due to a temporary issue on our side. Please try again
+          later.
+        </p>
+      </div>
+    ),
     snippets: {
       typescript: {
         loading: false,
-        error: (
-          <div className="flex flex-col gap-2 p-4">
-            <h3 className="text-base font-semibold text-rose-400">
-              Could not generate
-            </h3>
-            <p className="text-body-muted text-sm">
-              This might be due to a temporary issue on our side. Please try
-              again later.
-            </p>
-          </div>
-        ),
       },
     },
   },

--- a/src/components/CodePlayground/index.tsx
+++ b/src/components/CodePlayground/index.tsx
@@ -41,11 +41,6 @@ export interface CodePlaygroundSnippet {
    * Whether the code is loading.
    */
   loading?: boolean | undefined
-
-  /**
-   * The error to display in the playground if the code could not be loaded.
-   */
-  error?: React.ReactNode | undefined
 }
 
 export type CodePlaygroundSnippets = Partial<
@@ -58,6 +53,11 @@ export interface CodePlaygroundProps {
    * Accepts a `CodePlayground.Header` and a `CodePlayground.Footer` or a `CodePlayground.Code` component.
    */
   children: React.ReactNode
+
+  /**
+   * The error to display in the playground if the code could not be loaded.
+   */
+  error?: React.ReactNode | undefined
 
   /**
    * An object of snippets to display in the playground.
@@ -121,6 +121,7 @@ const CodePlayground = ({
   selectedLanguage,
   className,
   onChangeLanguage,
+  error,
   animateOnLanguageChange = true,
   showLineNumbers = true,
   wordWrap = true,
@@ -187,10 +188,10 @@ const CodePlayground = ({
   }, [codeRef.current])
 
   const codeContents = useMemo(() => {
-    return selectedCode.loading ? (
+    return error ? (
+      error
+    ) : selectedCode.loading ? (
       <div className="flex items-center p-4">{loadingSkeleton}</div>
-    ) : selectedCode.error ? (
-      selectedCode.error
     ) : highlighted ? (
       <Pre
         code={highlighted}
@@ -198,7 +199,7 @@ const CodePlayground = ({
         className="bg-muted/15 dark:bg-background relative m-0 mr-4 px-4 py-3 text-sm"
       />
     ) : null
-  }, [selectedCode.loading, selectedCode.error, highlighted])
+  }, [selectedCode.loading, highlighted])
 
   const foundCustomCodeContainer = useMemo(
     () =>


### PR DESCRIPTION
# What

The current API for annotating the code playground with an error causes issues with updating the error JSX with any state changes from parent components. This is a breaking change, but I think there is only one consumer using it, which I will update

This PR causes no visual change