### PR TITLE
fix: Add missing neutral color tokens

### DIFF
--- a/src/components/AIChat/parts/AIChatMessageToolPart.tsx
+++ b/src/components/AIChat/parts/AIChatMessageToolPart.tsx
@@ -1,3 +1,9 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/Tooltip'
 import { motion, MotionConfig } from 'framer-motion'
 import { CheckIcon, UserCheck, XIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
@@ -77,32 +83,46 @@ const defaultComponents: DefaultComponents<AIChatMessageToolPartComponents> = {
     </>
   ),
   approveButton: ({ onClick, className }) => (
-    <Button
-      size="icon"
-      variant="ghost"
-      onClick={onClick}
-      className={cn(
-        'border-em-600 h-6 w-6 bg-transparent text-emerald-300 hover:bg-emerald-800 hover:text-emerald-100',
-        className
-      )}
-      aria-label="Accept"
-    >
-      <CheckIcon className="h-4 w-4" />
-    </Button>
+    <TooltipProvider>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onClick}
+            className={cn(
+              'border-em-600 bg-success-fill text-success-foreground/90 hover:bg-success-fill/80 hover:text-success-foreground h-6 w-6',
+              className
+            )}
+            aria-label="Accept"
+          >
+            <CheckIcon className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Approve tool call</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   ),
   rejectButton: ({ onClick, className }) => (
-    <Button
-      size="icon"
-      variant="ghost"
-      onClick={onClick}
-      className={cn(
-        'h-6 w-6 text-red-400 hover:bg-red-800 hover:text-red-100',
-        className
-      )}
-      aria-label="Reject"
-    >
-      <XIcon className="h-4 w-4" />
-    </Button>
+    <TooltipProvider>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onClick}
+            className={cn(
+              'text-danger-fill hover:text-danger-fill hover:bg-danger-fill/30 h-6 w-6',
+              className
+            )}
+            aria-label="Reject"
+          >
+            <XIcon className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Reject tool call</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   ),
 }
 
@@ -164,7 +184,7 @@ export function AIChatMessageToolPart({
         {/* Header */}
         <div
           className={cn(
-            'flex items-center gap-3 border-neutral-700 bg-neutral-900 px-4 py-2',
+            'flex items-center gap-3 border-neutral-600 bg-neutral-900 px-4 py-2',
             {
               'border-b': isExpanded,
             }
@@ -327,7 +347,7 @@ const StatusIndicator = ({
           animate={{ scale: 1 }}
           transition={{ type: 'spring', stiffness: 500, damping: 15 }}
         >
-          <CheckIcon className="h-full w-full text-neutral-100 dark:text-neutral-900" />
+          <CheckIcon className="h-full w-full text-neutral-100" />
         </motion.div>
       )
     case 'error':
@@ -338,7 +358,7 @@ const StatusIndicator = ({
           animate={{ scale: 1 }}
           transition={{ type: 'spring', stiffness: 500, damping: 15 }}
         >
-          <XIcon className="h-full w-full text-neutral-100 dark:text-neutral-900" />
+          <XIcon className="h-full w-full text-neutral-100" />
         </motion.div>
       )
     case 'pending':
@@ -374,7 +394,7 @@ const StatusIndicator = ({
             animate={{ scale: 1 }}
             transition={{ type: 'spring', stiffness: 500, damping: 15 }}
           >
-            <UserCheck className="h-full w-full text-neutral-100 dark:text-neutral-900" />
+            <UserCheck className="h-full w-full text-neutral-100" />
           </motion.div>
         </>
       )

--- a/src/global.css
+++ b/src/global.css
@@ -219,6 +219,17 @@
   --color-accessibility: hsl(221 83% 53%);
   --color-transparent: hsla(0 0% 0% / 0);
 
+  --color-neutral-50: hsl(240 10% 4%);
+  --color-neutral-100: hsl(240 6% 10%);
+  --color-neutral-200: hsl(240 4% 16%);
+  --color-neutral-300: hsl(240 4% 24%);
+  --color-neutral-400: hsl(240 5% 34%);
+  --color-neutral-500: hsl(240 4% 46%);
+  --color-neutral-600: hsl(240 5% 65%);
+  --color-neutral-800: hsl(240 6% 90%);
+  --color-neutral-900: hsl(240 5% 96%);
+  --color-neutral-950: hsl(0 0% 98%);
+
   --color-brand-yellow-50: hsl(57 92% 95%);
   --color-brand-yellow-100: hsl(58 93% 88%);
   --color-brand-yellow-200: hsl(55 97% 77%);
@@ -306,6 +317,7 @@
   --color-neutral-50: hsl(0 0% 98%);
   --color-neutral-100: hsl(240 5% 96%);
   --color-neutral-200: hsl(240 6% 90%);
+  --color-neutral-300: hsl(240 5% 84%);
   --color-neutral-400: hsl(240 5% 65%);
   --color-neutral-500: hsl(240 4% 46%);
   --color-neutral-600: hsl(240 5% 34%);


### PR DESCRIPTION
These were removed perhaps by accident in [this PR](https://github.com/speakeasy-api/moonshine/pull/193/files), causing Gram styles to break in light mode

![CleanShot 2025-05-19 at 13 20 11@2x](https://github.com/user-attachments/assets/dec93ba3-a6ca-4f28-8321-0a29f13b809b)
![CleanShot 2025-05-19 at 13 22 38@2x](https://github.com/user-attachments/assets/fbc3e453-3aaf-4ff4-a281-8367a814675f)
