### PR TITLE
fix: app layout sidebar hover intent

### DIFF
--- a/src/components/AppLayout/context.tsx
+++ b/src/components/AppLayout/context.tsx
@@ -18,12 +18,14 @@ export interface AppLayoutContextType {
     toggle: KeybindConfig
   }
 
-  // hoverExpandsSidebar
+  /**
+   * If the sidebar is collapsed, should it expand when hovered?
+   */
   hoverExpandsSidebar: boolean
 
   // track if sidebar was expanded by hover vs manual toggle
-  expandedByHover: boolean
-  setExpandedByHover: (expandedByHover: boolean) => void
+  _expandedByHover: boolean
+  _setExpandedByHover: (expandedByHover: boolean) => void
 }
 
 export const AppLayoutContext = createContext<AppLayoutContextType>({
@@ -36,6 +38,6 @@ export const AppLayoutContext = createContext<AppLayoutContextType>({
     },
   },
   hoverExpandsSidebar: true,
-  expandedByHover: false,
-  setExpandedByHover: () => {},
+  _expandedByHover: false,
+  _setExpandedByHover: () => {},
 })

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -131,8 +131,8 @@ const AppLayoutSidebar = ({ children, className }: AppLayoutSidebarProps) => {
     collapsed,
     setCollapsed,
     hoverExpandsSidebar,
-    expandedByHover,
-    setExpandedByHover,
+    _expandedByHover,
+    _setExpandedByHover,
   } = useAppLayout()
 
   const [nav, rest] = partitionBy(Children.toArray(children), (child) => {
@@ -143,12 +143,12 @@ const AppLayoutSidebar = ({ children, className }: AppLayoutSidebarProps) => {
 
   const sidebarRef = useRef<HTMLDivElement>(null)
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const expandedByHoverRef = useRef(expandedByHover)
+  const expandedByHoverRef = useRef(_expandedByHover)
 
   // Keep ref in sync with state
   useEffect(() => {
-    expandedByHoverRef.current = expandedByHover
-  }, [expandedByHover])
+    expandedByHoverRef.current = _expandedByHover
+  }, [_expandedByHover])
 
   // Handle hover intent when the sidebar is collapsed
   useEffect(() => {
@@ -166,7 +166,7 @@ const AppLayoutSidebar = ({ children, className }: AppLayoutSidebarProps) => {
       // Set a delay before expanding
       hoverTimeoutRef.current = setTimeout(() => {
         setCollapsed(false)
-        setExpandedByHover(true) // Mark as expanded by hover
+        _setExpandedByHover(true) // Mark as expanded by hover
         hoverTimeoutRef.current = null
       }, 250) // 250ms delay
     }
@@ -181,7 +181,7 @@ const AppLayoutSidebar = ({ children, className }: AppLayoutSidebarProps) => {
       // Only collapse if it was expanded by hover, not manually
       if (expandedByHoverRef.current) {
         setCollapsed(true)
-        setExpandedByHover(false)
+        _setExpandedByHover(false)
       }
     }
 
@@ -198,7 +198,7 @@ const AppLayoutSidebar = ({ children, className }: AppLayoutSidebarProps) => {
       sidebar.removeEventListener('mouseenter', handleMouseEnter)
       sidebar.removeEventListener('mouseleave', handleMouseLeave)
     }
-  }, [hoverExpandsSidebar, collapsed, setCollapsed, setExpandedByHover])
+  }, [hoverExpandsSidebar, collapsed, setCollapsed, _setExpandedByHover])
 
   return (
     <motion.div
@@ -344,7 +344,7 @@ interface AppLayoutCollapseButtonProps extends PropsWithChildren {
 const AppLayoutCollapseButton = ({
   className,
 }: AppLayoutCollapseButtonProps) => {
-  const { collapsed, setCollapsed, keybinds, setExpandedByHover } =
+  const { collapsed, setCollapsed, keybinds, _setExpandedByHover } =
     useAppLayout()
   useAppLayoutKeys()
   return (
@@ -356,7 +356,7 @@ const AppLayoutCollapseButton = ({
               className="group typography-body-md hover:bg-accent hover:text-primary rounded-md p-1.5"
               onClick={() => {
                 setCollapsed(!collapsed)
-                setExpandedByHover(false) // Reset hover state on manual toggle
+                _setExpandedByHover(false) // Reset hover state on manual toggle
               }}
               aria-label="Toggle sidebar"
             >

--- a/src/components/AppLayout/provider.tsx
+++ b/src/components/AppLayout/provider.tsx
@@ -37,8 +37,8 @@ export const AppLayoutProvider = ({
         setCollapsed,
         keybinds: finalKeybinds,
         hoverExpandsSidebar,
-        expandedByHover,
-        setExpandedByHover,
+        _expandedByHover: expandedByHover,
+        _setExpandedByHover: setExpandedByHover,
       }}
     >
       {children}


### PR DESCRIPTION
# What

Adds a hover intent for when the app layout sidebar is collapsed, so if the user hovers over it then it will expand, and if their mouse leaves then it will go back to collapsed, if previously collapsed.

If the sidebar is expanded by default or by manual user action, then the hover intent behaviour is disabled.