### PR TITLE
fix(Tooltip): export Portal component from tooltip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export {
   TooltipTrigger,
   TooltipContent,
   TooltipProvider,
+  TooltipPortal,
 } from '@/components/Tooltip'
 export {
   Popover,


### PR DESCRIPTION
Extracting this for a quick, harmless merge so I can get a handle on the moonshine release process.