### PR TITLE
fix(Input): ensure event handlers are called

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -34,7 +34,7 @@ export function Input({
     },
     [props.onFocus]
   )
-  const onBlur = useCallback(
+  const handleBlur = useCallback(
     (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (props.onBlur) {
         props.onBlur(event)

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -69,8 +69,8 @@ export function Input({
       <textarea
         {...commonProps}
         {...props}
-        onFocus={onFocus}
-        onBlur={onBlur}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         cols={30}
         rows={10}
         className={cn(

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -55,8 +55,8 @@ export function Input({
     <input
       {...commonProps}
       {...props}
-      onFocus={onFocus}
-      onBlur={onBlur}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       className={cn(
         'bg-surface-primary-default placeholder:text-placeholder text-default h-full w-full text-sm shadow-none outline-none disabled:cursor-not-allowed disabled:opacity-50',
         isFocused && 'placeholder:text-default'

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -25,7 +25,7 @@ export function Input({
 }: InputProps) {
   const [isFocused, setIsFocused] = useState(false)
 
-  const handleFocus = useCallback(
+  const onFocus = useCallback(
     (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (props.onFocus) {
         props.onFocus(event)
@@ -34,7 +34,7 @@ export function Input({
     },
     [props.onFocus]
   )
-  const handleBlur = useCallback(
+  const onBlur = useCallback(
     (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (props.onBlur) {
         props.onBlur(event)
@@ -49,14 +49,14 @@ export function Input({
     onChange,
     placeholder,
     disabled,
-    onFocus: handleFocus,
-    onBlur: handleBlur,
   } as const
 
   let element: React.ReactNode = (
     <input
       {...commonProps}
       {...props}
+      onFocus={onFocus}
+      onBlur={onBlur}
       className={cn(
         'bg-surface-primary-default placeholder:text-placeholder text-default h-full w-full text-sm shadow-none outline-none disabled:cursor-not-allowed disabled:opacity-50',
         isFocused && 'placeholder:text-default'
@@ -69,6 +69,8 @@ export function Input({
       <textarea
         {...commonProps}
         {...props}
+        onFocus={onFocus}
+        onBlur={onBlur}
         cols={30}
         rows={10}
         className={cn(

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -25,7 +25,7 @@ export function Input({
 }: InputProps) {
   const [isFocused, setIsFocused] = useState(false)
 
-  const onFocus = useCallback(
+  const handleFocus = useCallback(
     (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (props.onFocus) {
         props.onFocus(event)


### PR DESCRIPTION
This seems more aligned with intended behavior. These handlers are explicitly calling the passed in props and it breaks our presentation of focus when users pass in focus or blur handlers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move `onFocus`/`onBlur` from shared props to element-level props to ensure passed handlers run and focus styling updates correctly.
> 
> - **Input component (`src/components/Input/index.tsx`)**:
>   - **Event handling**: Move `onFocus` and `onBlur` from `commonProps` to element-level props on `input` and `textarea` to ensure both passed-in handlers and internal focus state run correctly.
>   - **Styling behavior**: Maintains focused placeholder/text styling via `isFocused` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cc725e6a013e2edd5fe1dba9def8f480d848c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->