### PR TITLE
chore(ContextDropdown): silence warning for downstream people

### DIFF
--- a/src/components/ContextDropdown/index.tsx
+++ b/src/components/ContextDropdown/index.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import { useModal } from '@/hooks/useModal'
 import { Screen } from '@/context/ModalContext'
 
-const MotionHeading = motion(Heading)
+const MotionHeading = motion.create(Heading)
 
 const animationDuration = 0.15
 


### PR DESCRIPTION
I'm like pretty sure these interfaces are the same thing though technically not positive

<img width="628" height="103" alt="image" src="https://github.com/user-attachments/assets/1d1ca7e5-70b4-411f-afac-be69bc85022b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `motion(Heading)` with `motion.create(Heading)` in `src/components/ContextDropdown/index.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ab051df857222345cf7e493919452012297c06d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->