### PR TITLE
fix: React no longer logs key warning

### DIFF
--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -32,10 +32,13 @@ export interface SkeletonProps {
 export function Skeleton({ children, className }: SkeletonProps) {
   return (
     <div className="flex w-full flex-col items-start gap-2.5 select-none">
-      {Children.toArray(children).map((child) => {
+      {Children.toArray(children).map((child, index) => {
         if (typeof child === 'string') {
           return (
-            <div className="skeleton h-5 max-w-max min-w-36 rounded-lg text-transparent">
+            <div
+              key={index}
+              className="skeleton h-5 max-w-max min-w-36 rounded-lg text-transparent"
+            >
               {child}
             </div>
           )


### PR DESCRIPTION
## Why

- As far as I'm aware, re-creating the child tree on re-renders doesn't really pose a huge problem for this component, however, React generates extra noise in logs due to it:

<img width="761" height="874" alt="Screenshot 2025-10-24 at 10 33 03" src="https://github.com/user-attachments/assets/7dd6d6b8-4164-4f29-96d0-f4571670d301" />

## What

- This change silences that error