### PR TITLE
feat(Combobox): add create to combobox

### DIFF
--- a/src/components/Combobox/index.stories.tsx
+++ b/src/components/Combobox/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
 import { Combobox } from './index'
 
 const meta: Meta<typeof Combobox> = {
@@ -193,5 +194,35 @@ export const SearchableGroupedList: Story = {
     groups: generateGroupedList(20, 50),
     placeholder: 'Type to filter groups...',
     searchPlaceholder: 'Search groups and items...',
+  },
+}
+
+// Create new item example - demonstrates dynamic options
+export const WithCreateOption: Story = {
+  render: () => {
+    const [options, setOptions] = useState(generateList(10))
+    const [value, setValue] = useState<string | undefined>()
+
+    return (
+      <Combobox
+        options={options}
+        value={value!}
+        onValueChange={setValue}
+        placeholder="Search or create..."
+        searchPlaceholder="Type to search or create..."
+        createOptions={{
+          handleCreate: (query) => {
+            const newValue = query.toLowerCase().replace(/\s+/g, '-')
+            setOptions([...options, { value: newValue, label: query }])
+            setValue(newValue)
+          },
+          renderCreatePrompt: (query) => (
+            <span>
+              Create <strong>{query}</strong>
+            </span>
+          ),
+        }}
+      />
+    )
   },
 }

--- a/src/components/Combobox/index.tsx
+++ b/src/components/Combobox/index.tsx
@@ -52,6 +52,10 @@ interface ComboboxBaseProps<T extends string = string> {
   emptyText?: string
   searchPlaceholder?: string
   iconOnly?: boolean
+  createOptions?: {
+    handleCreate: (search: string) => void
+    renderCreatePrompt?: (search: string) => JSX.Element
+  }
 }
 
 export type ComboboxProps<T extends string = string> = ComboboxBaseProps<T> &
@@ -72,7 +76,9 @@ export function Combobox<T extends string = string>({
   placeholder = 'Select option...',
   emptyText = 'No option found.',
   searchPlaceholder = 'Search...',
+
   iconOnly = false,
+  createOptions,
 }: ComboboxProps<T>) {
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState('')
@@ -185,6 +191,19 @@ export function Combobox<T extends string = string>({
                 )}
               />
             )}
+            {(() => {
+              if (!createOptions || search.length === 0) return null
+              const { renderCreatePrompt, handleCreate } = createOptions
+              return (
+                <CommandGroup>
+                  <CommandItem onSelect={() => handleCreate(search)}>
+                    {renderCreatePrompt
+                      ? renderCreatePrompt(search)
+                      : `Create ${search}`}
+                  </CommandItem>
+                </CommandGroup>
+              )
+            })()}
           </CommandList>
         </Command>
       </PopoverContent>


### PR DESCRIPTION
Adds an option to supply a create callback to the combo box which allows you to create an item that you supply

<img width="291" height="203" alt="image" src="https://github.com/user-attachments/assets/d51e3a0b-e1e2-43b7-9f3b-2ef005a112f9" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `createOptions` API to `Combobox` to create a new option from the current search, with an example Storybook story.
> 
> - **Components**:
>   - `src/components/Combobox/index.tsx`
>     - Add `createOptions` prop with `handleCreate(search)` and optional `renderCreatePrompt(search)`.
>     - Render a "Create …" `CommandItem` when search is non-empty, invoking `handleCreate`.
> - **Storybook**:
>   - `src/components/Combobox/index.stories.tsx`
>     - Add `WithCreateOption` story demonstrating dynamic option creation using `useState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44bab5c6475db8d22955840b52974d8a71410984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->