### PR TITLE
chore(actions): update GitHub Actions runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           version: 9.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - run: pnpm install
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
 
       - run: pnpm install
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           version: 9.0.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install PNPM
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/published-test.yml
+++ b/.github/workflows/published-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/published-test.yml
+++ b/.github/workflows/published-test.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           version: 9.0.0
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - run: pnpm install
       - run: pnpm pack
 

--- a/.github/workflows/published-test.yml
+++ b/.github/workflows/published-test.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
 
       - run: pnpm install
       - run: pnpm pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
 
       - run: pnpm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           version: 9.0.0
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - run: pnpm install
 
       - run: pnpm test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           version: 9.0.0
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - run: pnpm install
 
       - run: pnpm type-check

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,7 +9,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
 
       - run: pnpm install
 


### PR DESCRIPTION
## Summary

This PR updates GitHub Actions workflows to use current action runtimes and Node 24. 

Node 20 runners have been [deprecated since Feb 26](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

- `actions/setup-node` is upgraded from v4 to v6 across CI, publish, and visual diff workflows. The workflows now explicitly run on Node 24, matching the newer action runtime and keeping CI aligned with current GitHub-hosted runner support.
- `actions/checkout` is also upgraded to v6 across all workflows. Existing workflow behavior is preserved, including full-history checkout for Chromatic visual diff.
- The test, typecheck, and published package test workflows now include an explicit Node setup step before dependency installation, instead of relying on the runner default Node version.

### Note:

Left `pnpm/action-setup` to v4, this still supports pnpm 9.x and latest v4 has node24 support. Will need to upgrade when we upgrade to pnpm v11
