### PR TITLE
feat(table): add controlled sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "rimraf dist",
     "build": "pnpm clean && vite build",
     "build:watch": "vite build --watch --mode development",
-    "type-check": "tsc --noEmit --skipLibCheck",
+    "type-check": "tsc -p tsconfig.typecheck.json --skipLibCheck",
     "prepack": "pnpm build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Column, Group, Table, TableProps } from '.'
+import {
+  Table,
+  type Column,
+  type Group,
+  type SortDescriptor,
+  type TableProps,
+} from '.'
+import { sortTableData } from './sorting'
 import { faker } from '@faker-js/faker'
 import { useState } from 'react'
 import { SupportedLanguage, supportedLanguages } from '@/types'
@@ -108,6 +115,40 @@ const defaultArgs: ListTableProps = {
 
 type ListTableProps = TableProps<SDK> & { data: SDK[] }
 
+const sortableColumns: Column<SDK>[] = defaultArgs.columns.map(
+  (column): Column<SDK> => {
+    if (column.key === 'name') {
+      return {
+        ...column,
+        id: 'sdk-name',
+        sortable: true,
+        sortValue: (row) => `${row.org}/${row.name}`,
+      }
+    }
+
+    if (column.key === 'version') {
+      return {
+        ...column,
+        id: 'sdk-version',
+        sortable: true,
+        sortValue: (row) => row.version,
+      }
+    }
+
+    if (column.key === 'lastGeneratedAt') {
+      return {
+        ...column,
+        id: 'sdk-last-generated-at',
+        sortable: true,
+        sortLabel: 'Last Generated',
+        sortValue: (row) => row.lastGeneratedAt,
+      }
+    }
+
+    return column
+  }
+)
+
 const TableWithState = (args: ListTableProps) => {
   const [data, setData] = useState<SDK[]>(args.data)
   return (
@@ -121,9 +162,37 @@ const TableWithState = (args: ListTableProps) => {
   )
 }
 
+const SortableTableWithState = (args: ListTableProps) => {
+  const [data, setData] = useState<SDK[]>(args.data)
+  const [sort, setSort] = useState<SortDescriptor | null>(null)
+
+  const sortedData = sortTableData(data, args.columns, sort) as SDK[]
+
+  return (
+    <Table
+      {...args}
+      data={sortedData}
+      sort={sort}
+      onSortChange={setSort}
+      onLoadMore={async () => {
+        setData((prev) => [...prev, ...generateSDKs(2)])
+      }}
+    />
+  )
+}
+
 export const Default: StoryObj<ListTableProps> = {
   args: defaultArgs,
   render: (args) => <TableWithState {...args} />,
+}
+
+export const Sortable: StoryObj<ListTableProps> = {
+  args: {
+    ...defaultArgs,
+    columns: sortableColumns,
+    hasMore: false,
+  },
+  render: (args) => <SortableTableWithState {...args} />,
 }
 
 export const Condensed: StoryObj<ListTableProps> = {

--- a/src/components/Table/index.test.tsx
+++ b/src/components/Table/index.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Table, type Column } from './index'
+
+type SDK = {
+  name: string
+  version: string
+  lastGeneratedAt: Date | null
+}
+
+const rows: SDK[] = [
+  {
+    name: 'typescript',
+    version: '10.0.0',
+    lastGeneratedAt: new Date('2026-05-03T00:00:00.000Z'),
+  },
+  {
+    name: 'go',
+    version: '2.0.0',
+    lastGeneratedAt: new Date('2026-05-01T00:00:00.000Z'),
+  },
+]
+
+const columns: Column<SDK>[] = [
+  {
+    key: 'name',
+    id: 'sdk-name',
+    header: 'SDK',
+    sortable: true,
+    sortValue: (row) => row.name,
+  },
+  {
+    key: 'lastGeneratedAt',
+    header: 'Last Generated',
+    sortable: true,
+    sortLabel: 'Last Generated',
+    render: (row) =>
+      row.lastGeneratedAt ? row.lastGeneratedAt.toISOString() : 'Never',
+    sortValue: (row) => row.lastGeneratedAt,
+  },
+]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('Table sortable headers', () => {
+  it('cycles controlled sortable header clicks from ascending to descending to cleared', () => {
+    const onSortChange = vi.fn()
+
+    const { rerender } = render(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={null}
+        onSortChange={onSortChange}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sort by SDK ascending' })
+    )
+    expect(onSortChange).toHaveBeenLastCalledWith({
+      id: 'sdk-name',
+      direction: 'asc',
+    })
+
+    rerender(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={{ id: 'sdk-name', direction: 'asc' }}
+        onSortChange={onSortChange}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sort by SDK descending' })
+    )
+    expect(onSortChange).toHaveBeenLastCalledWith({
+      id: 'sdk-name',
+      direction: 'desc',
+    })
+
+    rerender(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={{ id: 'sdk-name', direction: 'desc' }}
+        onSortChange={onSortChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear sort for SDK' }))
+    expect(onSortChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('adds aria-sort only to the active sorted column', () => {
+    render(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={{ id: 'lastGeneratedAt', direction: 'desc' }}
+        onSortChange={() => undefined}
+      />
+    )
+
+    expect(
+      screen
+        .getByRole('columnheader', { name: /last generated/i })
+        .getAttribute('aria-sort')
+    ).toBe('descending')
+    expect(
+      screen
+        .getByRole('columnheader', { name: /sdk/i })
+        .getAttribute('aria-sort')
+    ).toBeNull()
+  })
+
+  it('styles inactive sort icon lighter and active sort icon darker', () => {
+    const { rerender } = render(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={null}
+        onSortChange={() => undefined}
+      />
+    )
+
+    const inactiveIcon = screen
+      .getByRole('button', { name: 'Sort by SDK ascending' })
+      .querySelector('svg')
+
+    expect(inactiveIcon?.classList.contains('text-body-muted')).toBe(true)
+    expect(inactiveIcon?.classList.contains('group-hover:text-body')).toBe(true)
+
+    rerender(
+      <Table
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={{ id: 'sdk-name', direction: 'asc' }}
+        onSortChange={() => undefined}
+      />
+    )
+
+    const activeIcon = screen
+      .getByRole('button', { name: 'Sort by SDK descending' })
+      .querySelector('svg')
+
+    expect(activeIcon?.classList.contains('text-body')).toBe(true)
+    expect(activeIcon?.classList.contains('text-body-muted')).toBe(false)
+  })
+
+  it('renders sortable columns as plain headers when onSortChange is missing', () => {
+    render(<Table columns={columns} data={rows} rowKey={(row) => row.name} />)
+
+    expect(screen.queryByRole('button', { name: /sort by sdk/i })).toBeNull()
+    expect(screen.getByRole('columnheader', { name: /sdk/i })).toBeTruthy()
+  })
+
+  it('warns in development when sortable ids are duplicated', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const duplicateColumns: Column<SDK>[] = [
+      columns[0],
+      {
+        ...columns[1],
+        id: 'sdk-name',
+      },
+    ]
+
+    render(
+      <Table
+        columns={duplicateColumns}
+        data={rows}
+        rowKey={(row) => row.name}
+        sort={null}
+        onSortChange={() => undefined}
+      />
+    )
+
+    expect(warn).toHaveBeenCalledWith(
+      'Table sortable columns must have unique ids. Duplicate id: sdk-name'
+    )
+  })
+})

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from 'react'
 import { cn } from '@/lib/utils'
-import { Loader2 } from 'lucide-react'
+import { ArrowDown, ArrowUp, ArrowUpDown, Loader2 } from 'lucide-react'
 import { isGroupOf } from '@/lib/typeUtils'
 import styles from './styles.module.css'
 import {
@@ -22,13 +22,42 @@ import { Button } from '@/components/Button'
 import { ExpandChevron } from '@/components/__beta__/CLIWizard'
 import { TableProvider } from './context/tableProvider'
 import { useTable } from './context/context'
+import { getColumnSortId, isSortableColumn } from './sorting'
 
-export type Column<T extends object> = {
-  key: keyof T | string
+export type SortDirection = 'asc' | 'desc'
+
+export type SortValue = string | number | boolean | Date | null | undefined
+
+type ColumnKey<T extends object> = keyof T | string
+
+export type SortDescriptor = {
+  id: string
+  direction: SortDirection
+}
+
+type BaseColumn<T extends object> = {
+  key: ColumnKey<T>
+  id?: string
   header: ReactNode
   render?: (row: T) => ReactNode
   width?: `${number}fr` | `${number}px` | 'auto' | undefined
 }
+
+export type SortableColumn<T extends object> = BaseColumn<T> & {
+  sortable: true
+  sortLabel?: string
+  sortValue: (row: T) => SortValue
+  sortCompare?: (a: T, b: T) => number
+}
+
+type UnsortableColumn<T extends object> = BaseColumn<T> & {
+  sortable?: false
+  sortLabel?: never
+  sortValue?: never
+  sortCompare?: never
+}
+
+export type Column<T extends object> = SortableColumn<T> | UnsortableColumn<T>
 
 export type Group<T extends object> = {
   key: string
@@ -53,6 +82,8 @@ export type TableProps<T extends object> = {
   className?: string
   cellPadding?: CellPadding
   hideHeader?: boolean
+  sort?: SortDescriptor | null
+  onSortChange?: (sort: SortDescriptor | null) => void
 }
 
 export type TableWrapperProps<T extends object> =
@@ -66,6 +97,31 @@ function expandColumn<T extends object>(): Column<T> {
     key: 'expand',
     header: '',
     width: `64px`, // 32px is padding, 32px is the width of the expand button
+  }
+}
+
+function warnOnDuplicateSortableIds<T extends object>(columns: Column<T>[]) {
+  if (process.env.NODE_ENV === 'production') {
+    return
+  }
+
+  const seen = new Set<string>()
+
+  for (const column of columns) {
+    if (!isSortableColumn(column)) {
+      continue
+    }
+
+    const id = getColumnSortId(column)
+
+    if (seen.has(id)) {
+      console.warn(
+        `Table sortable columns must have unique ids. Duplicate id: ${id}`
+      )
+      return
+    }
+
+    seen.add(id)
   }
 }
 
@@ -129,6 +185,8 @@ function TableRoot<T extends object>(
     columns = [expandColumn(), ...columns]
   }
 
+  warnOnDuplicateSortableIds(columns)
+
   const colWidths = useMemo(
     () => columns.map((column) => column.width ?? '1fr').join(' '),
     [columns]
@@ -160,6 +218,8 @@ function TableRoot<T extends object>(
     className,
     hideHeader,
     cellPadding,
+    sort,
+    onSortChange,
   } = props
 
   const [isLoading, setIsLoading] = useState(false)
@@ -188,7 +248,13 @@ function TableRoot<T extends object>(
       ref={tableRef}
       expandedRowKeys={expandedRowKeys}
     >
-      {!hideHeader && <Table.Header columns={columns} />}
+      {!hideHeader && (
+        <Table.Header
+          columns={columns}
+          sort={sort}
+          onSortChange={onSortChange}
+        />
+      )}
       <Table.Body
         data={data}
         ref={tableBodyRef}
@@ -208,6 +274,8 @@ function TableRoot<T extends object>(
 
 type HeaderProps<T extends object> = {
   columns: Column<T>[]
+  sort?: SortDescriptor | null
+  onSortChange?: (sort: SortDescriptor | null) => void
   className?: string
 }
 
@@ -227,6 +295,109 @@ function HeaderContainer({
   )
 }
 
+function getSortDirection<T extends object>(
+  column: Column<T>,
+  sort: SortDescriptor | null | undefined
+) {
+  return sort?.id === getColumnSortId(column) ? sort.direction : undefined
+}
+
+function getSortLabel<T extends object>(column: SortableColumn<T>) {
+  return (
+    column.sortLabel ??
+    (typeof column.header === 'string'
+      ? column.header
+      : getColumnSortId(column))
+  )
+}
+
+function getNextSort<T extends object>(
+  column: SortableColumn<T>,
+  sort: SortDescriptor | null | undefined
+): SortDescriptor | null {
+  const direction = getSortDirection(column, sort)
+  const id = getColumnSortId(column)
+
+  if (direction === 'asc') {
+    return { id, direction: 'desc' }
+  }
+
+  if (direction === 'desc') {
+    return null
+  }
+
+  return { id, direction: 'asc' }
+}
+
+function getSortButtonLabel<T extends object>(
+  column: SortableColumn<T>,
+  sort: SortDescriptor | null | undefined
+) {
+  const label = getSortLabel(column)
+  const direction = getSortDirection(column, sort)
+
+  if (direction === 'asc') {
+    return `Sort by ${label} descending`
+  }
+
+  if (direction === 'desc') {
+    return `Clear sort for ${label}`
+  }
+
+  return `Sort by ${label} ascending`
+}
+
+function SortableHeaderCell<T extends object>({
+  column,
+  sort,
+  onSortChange,
+}: {
+  column: Column<T>
+  sort?: SortDescriptor | null
+  onSortChange?: (sort: SortDescriptor | null) => void
+}) {
+  if (!isSortableColumn(column) || !onSortChange) {
+    return <HeaderCell>{column.header}</HeaderCell>
+  }
+
+  const direction = getSortDirection(column, sort)
+  const isSorted = direction !== undefined
+  const Icon =
+    direction === 'asc'
+      ? ArrowUp
+      : direction === 'desc'
+        ? ArrowDown
+        : ArrowUpDown
+
+  return (
+    <HeaderCell
+      aria-sort={
+        direction === 'asc'
+          ? 'ascending'
+          : direction === 'desc'
+            ? 'descending'
+            : undefined
+      }
+    >
+      <button
+        type="button"
+        className="group flex h-full w-full min-w-0 items-center gap-1 text-left font-medium"
+        aria-label={getSortButtonLabel(column, sort)}
+        onClick={() => onSortChange(getNextSort(column, sort))}
+      >
+        <span className="min-w-0 truncate">{column.header}</span>
+        <Icon
+          aria-hidden="true"
+          className={cn(
+            'size-3.5 shrink-0 transition-colors',
+            isSorted ? 'text-body' : 'text-body-muted group-hover:text-body'
+          )}
+        />
+      </button>
+    </HeaderCell>
+  )
+}
+
 function Header<T extends object>(
   props: HeaderProps<T> | PropsWithChildrenAndClassName
 ) {
@@ -242,7 +413,12 @@ function Header<T extends object>(
     <HeaderContainer className={props.className}>
       <tr className="table-header [grid-column:1/-1] grid [grid-template-columns:subgrid] border-b">
         {props.columns.map((column) => (
-          <HeaderCell key={column.key.toString()}>{column.header}</HeaderCell>
+          <SortableHeaderCell
+            key={`${column.key.toString()}-${column.id ?? ''}`}
+            column={column}
+            sort={props.sort}
+            onSortChange={props.onSortChange}
+          />
         ))}
       </tr>
     </HeaderContainer>
@@ -661,12 +837,15 @@ function LoadMore<T extends object>({
   )
 }
 
-function HeaderCell({
-  className,
-  children,
-}: PropsWithChildren<{ className?: string }>) {
+type HeaderCellProps = React.ThHTMLAttributes<HTMLTableCellElement> &
+  PropsWithChildren<{
+    className?: string
+  }>
+
+function HeaderCell({ className, children, ...props }: HeaderCellProps) {
   return (
     <th
+      {...props}
       className={cn(
         styles.tableHeader,
         'text-body flex items-center align-middle font-medium whitespace-nowrap select-none',

--- a/src/components/Table/sorting.test.ts
+++ b/src/components/Table/sorting.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { Column, Group } from './index'
+import {
+  compareSortValues,
+  getColumnSortId,
+  sortRows,
+  sortTableData,
+} from './sorting'
+
+type SDK = {
+  name: string
+  version: string
+  priority: 'low' | 'medium' | 'high'
+  lastGeneratedAt: Date | null
+}
+
+const rows: SDK[] = [
+  {
+    name: 'typescript',
+    version: '10.0.0',
+    priority: 'medium',
+    lastGeneratedAt: new Date('2026-05-03T00:00:00.000Z'),
+  },
+  {
+    name: 'go',
+    version: '2.0.0',
+    priority: 'high',
+    lastGeneratedAt: new Date('2026-05-01T00:00:00.000Z'),
+  },
+  {
+    name: 'python',
+    version: '1.0.0',
+    priority: 'low',
+    lastGeneratedAt: null,
+  },
+]
+
+const columns: Column<SDK>[] = [
+  {
+    key: 'name',
+    id: 'sdk-name',
+    header: 'SDK',
+    sortable: true,
+    sortValue: (row) => row.name,
+  },
+  {
+    key: 'lastGeneratedAt',
+    header: 'Last Generated',
+    sortable: true,
+    sortValue: (row) => row.lastGeneratedAt,
+  },
+  {
+    key: 'priority',
+    header: 'Priority',
+    sortable: true,
+    sortValue: (row) => row.priority,
+    sortCompare: (a, b) => {
+      const rank = { low: 0, medium: 1, high: 2 }
+      return rank[a.priority] - rank[b.priority]
+    },
+  },
+]
+
+describe('Table sorting helpers', () => {
+  it('uses explicit id before key for sort identity', () => {
+    expect(getColumnSortId(columns[0])).toBe('sdk-name')
+    expect(getColumnSortId(columns[1])).toBe('lastGeneratedAt')
+  })
+
+  it('compares strings, numbers, booleans, dates, and nulls consistently', () => {
+    expect(compareSortValues('a', 'b')).toBeLessThan(0)
+    expect(compareSortValues(2, 1)).toBeGreaterThan(0)
+    expect(compareSortValues(false, true)).toBeLessThan(0)
+    expect(
+      compareSortValues(new Date('2026-05-01'), new Date('2026-05-02'))
+    ).toBeLessThan(0)
+    expect(compareSortValues(null, 'a')).toBeGreaterThan(0)
+    expect(compareSortValues(undefined, null)).toBe(0)
+  })
+
+  it('sortRows keeps null values last in both directions', () => {
+    const dateColumn = columns[1]
+
+    if (!dateColumn.sortable) {
+      throw new Error('date column must be sortable')
+    }
+
+    expect(sortRows(rows, dateColumn, 'asc').map((row) => row.name)).toEqual([
+      'go',
+      'typescript',
+      'python',
+    ])
+
+    expect(sortRows(rows, dateColumn, 'desc').map((row) => row.name)).toEqual([
+      'typescript',
+      'go',
+      'python',
+    ])
+  })
+
+  it('sortRows uses custom sortCompare when provided', () => {
+    const priorityColumn = columns[2]
+
+    if (!priorityColumn.sortable) {
+      throw new Error('priority column must be sortable')
+    }
+
+    expect(
+      sortRows(rows, priorityColumn, 'desc').map((row) => row.priority)
+    ).toEqual(['high', 'medium', 'low'])
+  })
+
+  it('sortRows keeps equal non-null values in original order', () => {
+    const duplicateRows: SDK[] = [
+      { ...rows[0], name: 'duplicate' },
+      { ...rows[1], name: 'duplicate' },
+      { ...rows[2], name: 'alpha' },
+    ]
+    const nameColumn = columns[0]
+
+    if (!nameColumn.sortable) {
+      throw new Error('name column must be sortable')
+    }
+
+    expect(sortRows(duplicateRows, nameColumn, 'asc')).toEqual([
+      duplicateRows[2],
+      duplicateRows[0],
+      duplicateRows[1],
+    ])
+  })
+
+  it('sortTableData returns original data when sort is null or unknown', () => {
+    expect(sortTableData(rows, columns, null)).toBe(rows)
+    expect(
+      sortTableData(rows, columns, { id: 'missing', direction: 'asc' })
+    ).toBe(rows)
+  })
+
+  it('sortTableData sorts flat rows without mutating input', () => {
+    const sorted = sortTableData(rows, columns, {
+      id: 'sdk-name',
+      direction: 'asc',
+    }) as SDK[]
+
+    expect(sorted.map((row) => row.name)).toEqual([
+      'go',
+      'python',
+      'typescript',
+    ])
+    expect(rows.map((row) => row.name)).toEqual(['typescript', 'go', 'python'])
+  })
+
+  it('sortTableData sorts rows inside groups without reordering groups', () => {
+    const groupedRows: Group<SDK>[] = [
+      { key: 'group-a', items: [rows[0], rows[1]] },
+      { key: 'group-b', items: [rows[2]] },
+    ]
+
+    const sorted = sortTableData(groupedRows, columns, {
+      id: 'sdk-name',
+      direction: 'asc',
+    }) as Group<SDK>[]
+
+    expect(sorted.map((group) => group.key)).toEqual(['group-a', 'group-b'])
+    expect(sorted[0].items.map((row) => row.name)).toEqual(['go', 'typescript'])
+  })
+})

--- a/src/components/Table/sorting.ts
+++ b/src/components/Table/sorting.ts
@@ -1,0 +1,129 @@
+import { isGroupOf } from '@/lib/typeUtils'
+import type {
+  Column,
+  Group,
+  SortableColumn,
+  SortDescriptor,
+  SortDirection,
+  SortValue,
+} from './index'
+
+export function isSortableColumn<T extends object>(
+  column: Column<T>
+): column is SortableColumn<T> {
+  return column.sortable === true
+}
+
+export function getColumnSortId<T extends object>(column: Column<T>) {
+  return column.id ?? column.key.toString()
+}
+
+function isGroupedData<T extends object>(
+  data: T[] | Group<T>[]
+): data is Group<T>[] {
+  return data.every((item) => isGroupOf<T>(item))
+}
+
+function normalizeSortValue(value: Exclude<SortValue, null | undefined>) {
+  return value instanceof Date ? value.getTime() : value
+}
+
+export function compareSortValues(a: SortValue, b: SortValue): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+
+  const normalizedA = normalizeSortValue(a)
+  const normalizedB = normalizeSortValue(b)
+
+  if (typeof normalizedA === 'string' && typeof normalizedB === 'string') {
+    return normalizedA.localeCompare(normalizedB, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    })
+  }
+
+  if (normalizedA === normalizedB) return 0
+
+  return normalizedA > normalizedB ? 1 : -1
+}
+
+export function sortRows<T extends object>(
+  rows: T[],
+  column: SortableColumn<T>,
+  direction: SortDirection
+) {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const aValue = column.sortValue(a.row)
+      const bValue = column.sortValue(b.row)
+
+      if (aValue == null && bValue != null) return 1
+      if (bValue == null && aValue != null) return -1
+
+      const comparison = column.sortCompare
+        ? column.sortCompare(a.row, b.row)
+        : compareSortValues(aValue, bValue)
+
+      if (comparison === 0) {
+        return a.index - b.index
+      }
+
+      return direction === 'asc' ? comparison : -comparison
+    })
+    .map(({ row }) => row)
+}
+
+/**
+ * Sorts table data with the same sort descriptors emitted by `Table`.
+ *
+ * `Table` only renders sortable headers and calls `onSortChange`; it never
+ * reorders `data` internally. Use this helper when the caller wants simple
+ * client-side sorting for rows already loaded in memory.
+ *
+ * For grouped data, group order is preserved and only each group's `items`
+ * array is sorted. If `sort` is `null` or references a missing/non-sortable
+ * column, the original `data` reference is returned unchanged.
+ *
+ * @example
+ * const [sort, setSort] = useState<SortDescriptor | null>(null)
+ * const sortedData = sortTableData(data, columns, sort)
+ *
+ * return (
+ *   <Table
+ *     columns={columns}
+ *     data={sortedData}
+ *     rowKey={(row) => row.id}
+ *     sort={sort}
+ *     onSortChange={setSort}
+ *   />
+ * )
+ */
+export function sortTableData<T extends object>(
+  data: T[] | Group<T>[],
+  columns: Column<T>[],
+  sort: SortDescriptor | null | undefined
+): T[] | Group<T>[] {
+  if (!sort) {
+    return data
+  }
+
+  const column = columns.find(
+    (candidate) =>
+      getColumnSortId(candidate) === sort.id && isSortableColumn(candidate)
+  )
+
+  if (!column || !isSortableColumn(column)) {
+    return data
+  }
+
+  if (isGroupedData(data)) {
+    return data.map((group) => ({
+      ...group,
+      items: sortRows(group.items, column, sort.direction),
+    }))
+  }
+
+  return sortRows(data, column, sort.direction)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,11 @@ export {
   type TableProps,
   type Column,
   type Group,
+  type SortDescriptor,
+  type SortDirection,
+  type SortValue,
 } from '@/components/Table'
+export { sortTableData } from '@/components/Table/sorting'
 export { Input, type InputProps } from '@/components/Input'
 export {
   type SupportedLanguage,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "type-tests"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.stories.@(mdx|tsx)",
+    "src/**/*.test.@(ts|tsx)"
+  ]
+}

--- a/type-tests/table-sort.ts
+++ b/type-tests/table-sort.ts
@@ -1,0 +1,26 @@
+import type { Column, SortDescriptor } from '../src/components/Table'
+
+type TypeCheckRow = { name: string }
+
+// @ts-expect-error sortable columns must define sortValue
+const sortableColumnRequiresSortValue: Column<TypeCheckRow> = {
+  key: 'name',
+  header: 'Name',
+  sortable: true,
+}
+
+const validSortableColumn: Column<TypeCheckRow> = {
+  key: 'name',
+  header: 'Name',
+  sortable: true,
+  sortValue: (row) => row.name,
+}
+
+const sortDescriptorUsesStableId: SortDescriptor = {
+  id: 'name',
+  direction: 'asc',
+}
+
+void sortableColumnRequiresSortValue
+void validSortableColumn
+void sortDescriptorUsesStableId


### PR DESCRIPTION
## Summary

This adds optional, controlled single-column sorting to the `Table` component.

`Table` now knows how to render sortable header controls, reflect the active sort state, and emit sort changes through `onSortChange`. It still does **not** reorder rows internally. Callers continue to own data order, whether they sort already-loaded data in memory or refetch sorted data from a server.

## Visual

https://github.com/user-attachments/assets/07f65c04-d02a-45fd-9bb1-ac159e47b641

## What Changed

- Added controlled sort props:
  - `sort?: SortDescriptor | null`
  - `onSortChange?: (sort: SortDescriptor | null) => void`
- Added public sort types:
  - `SortDescriptor`
  - `SortDirection`
  - `SortValue`
- Added sortable column support with `sortable: true`.
- Required `sortValue` for sortable columns so sorting does not depend on rendered React nodes.
- Added optional sortable column fields:
  - `id` for stable sort identity when `key` is not enough
  - `sortLabel` for accessible labels when the visible header is not plain text
  - `sortCompare` for custom ordering, such as priority enums or semantic versions
- Added accessible sortable header buttons:
  - first click sorts ascending
  - second click sorts descending
  - third click clears sorting
  - active sorted header gets `aria-sort`
  - buttons get direction-aware `aria-label`
- Added inactive/active sort icon states:
  - inactive icon is lighter
  - hover and active sort state use darker text
- Added a development warning for duplicate sortable column ids.
- Added caller-side sorting helpers in `src/components/Table/sorting.ts`:
  - `sortTableData`
  - `sortRows`
  - `compareSortValues`
  - `getColumnSortId`
- Added a Storybook `Sortable` story that demonstrates caller-managed local sorting with `sortTableData`.

## Design Notes

The important design choice is that `Table` remains controlled. It renders sort UI and emits the next sort descriptor, but it does not mutate or reorder `data`.

That keeps the component usable for both client-side and server-side sorting:

- Client-side callers can use `sortTableData(data, columns, sort)`.
- Server-side callers can listen to `onSortChange`, fetch sorted rows, then pass those rows back into `Table`.

`sortValue` is required for sortable columns because rendered cells can be arbitrary React. A cell might display combined text, icons, badges, relative dates, or custom markup. Rather than trying to infer a sortable value from rendered output, the caller provides the canonical value.

`sortTableData` is intentionally optional. It is a convenience for simple in-memory sorting, not a requirement for using sortable headers.

For grouped data, `sortTableData` preserves group order and sorts only each group’s `items`. It does not attempt to reorder groups.

## Existing Table Impact

Existing tables should keep their current behavior because all sorting props are optional.

- Columns are not sortable unless `sortable: true` is set.
- Sortable headers only render as buttons when `onSortChange` is provided.
- `Table` does not sort data unless the caller explicitly passes sorted data back in.
- Existing non-sortable columns and existing rendered cells continue to work as before.

## Test Plan

- `pnpm test -- --run`
- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `pnpm build-storybook`

## Coverage Added

- Header click cycle: ascending -> descending -> cleared
- `aria-sort` on the active sorted column only
- inactive and active sort icon styling
- no sortable button behavior when `onSortChange` is missing
- duplicate sortable id warning
- flat row sorting without mutating the input array
- grouped data sorting without reordering groups
- null/undefined values sorted last in both directions
- custom comparator support
- compile-time assertion that `sortable: true` requires `sortValue`


https://linear.app/speakeasy/issue/DES-422/feat-add-sort-feature-to-table-component