### PR TITLE
chore(storybook): change dev port from 6006 to 7006

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build:watch": "vite build --watch --mode development",
     "type-check": "tsc -p tsconfig.typecheck.json --skipLibCheck",
     "prepack": "pnpm build",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 7006",
     "build-storybook": "storybook build",
     "lint": "eslint",
     "lint:fix": "eslint --fix",


### PR DESCRIPTION
## Summary
- Changes Storybook dev server port from 6006 to 7006
- Avoids conflict with other repos (e.g. gram) that run Storybook on the default 6006 port

## Test Plan
- [x] Run `pnpm storybook` and confirm it starts on port 7006
