### PR TITLE
chore(deps): upgrade pnpm 9 → 11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Install PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/published-test.yml
+++ b/.github/workflows/published-test.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@speakeasy-api/moonshine",
   "version": "1.9.1",
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@11.4.0",
   "description": "Speakeasy's design system Moonshine",
   "sideEffects": false,
   "main": "dist/moonshine.cjs.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Bumps `packageManager` from `pnpm@9.0.0` to `pnpm@11.4.0` to align with gram
- Adds `pnpm-workspace.yaml` to approve esbuild's postinstall build scripts (required by pnpm 11's new security model)

## Test Plan

- [ ] CI passes (lint, typecheck, tests)