### PR TITLE
docs(tooltip): improve Storybook docs

### DIFF
--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -1,11 +1,26 @@
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { Copy, ExternalLink, PlusIcon as LucidePlusIcon } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from '.'
 import { Button } from '../Button'
+import { IconButton } from '../IconButton'
 
 const meta: Meta<typeof Tooltip> = {
   component: Tooltip,
+  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Tooltip wraps Radix Tooltip primitives with Moonshine styling. Use `TooltipTrigger asChild` with Button or IconButton so the trigger remains the interactive element.',
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -20,15 +35,171 @@ export default meta
 
 type Story = StoryObj<typeof Tooltip>
 
+function PlusIcon(props: React.ComponentProps<typeof LucidePlusIcon>) {
+  return <LucidePlusIcon {...props} />
+}
+
 export const Default: Story = {
   args: {
     children: [
-      <TooltipTrigger>
+      <TooltipTrigger asChild>
         <Button variant="secondary">Hover me</Button>
       </TooltipTrigger>,
-      <TooltipContent side="right">
-        <p>You hovered me!</p>
+      <TooltipContent>
+        <p>Helpful context for this action.</p>
       </TooltipContent>,
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default pattern uses `TooltipTrigger asChild` so the Button receives pointer and focus events directly.',
+      },
+    },
+  },
+}
+
+export const WithIconButton: Story = {
+  args: {
+    children: [
+      <TooltipTrigger asChild>
+        <IconButton
+          icon={<Copy />}
+          variant="secondary"
+          aria-label="Copy endpoint"
+        />
+      </TooltipTrigger>,
+      <TooltipContent>Copy endpoint</TooltipContent>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only actions should keep a visible tooltip and an accessible `aria-label` on the IconButton.',
+      },
+    },
+  },
+}
+
+export const WithButtonIcons: Story = {
+  args: {
+    delayDuration: 150,
+    children: [
+      <TooltipTrigger asChild>
+        <Button variant="primary" size="sm">
+          <Button.LeftIcon>
+            <PlusIcon />
+          </Button.LeftIcon>
+          <Button.Text>Create</Button.Text>
+          <Button.RightIcon>
+            <ExternalLink />
+          </Button.RightIcon>
+        </Button>
+      </TooltipTrigger>,
+      <TooltipContent>Create project</TooltipContent>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tooltip works with Button compound components, including left and right icons.',
+      },
+    },
+  },
+}
+
+export const Placement: Story = {
+  args: {
+    defaultOpen: true,
+    children: [
+      <TooltipTrigger asChild>
+        <Button variant="secondary" size="sm">
+          Right side
+        </Button>
+      </TooltipTrigger>,
+      <TooltipContent side="right">Appears on the right</TooltipContent>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'TooltipContent accepts Radix placement props such as `side`.',
+      },
+    },
+  },
+}
+
+export const WithPortal: Story = {
+  name: 'With Portal',
+  args: {
+    defaultOpen: true,
+    children: [
+      <TooltipTrigger asChild>
+        <Button variant="secondary">Portaled tooltip</Button>
+      </TooltipTrigger>,
+      <TooltipPortal>
+        <TooltipContent side="top" sideOffset={8}>
+          Rendered in a portal
+        </TooltipContent>
+      </TooltipPortal>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use TooltipPortal when the tooltip needs to escape parent stacking or overflow contexts.',
+      },
+    },
+  },
+}
+
+export const DelayDuration: Story = {
+  args: {
+    delayDuration: 700,
+    children: [
+      <TooltipTrigger asChild>
+        <Button variant="secondary" size="sm">
+          Delayed
+        </Button>
+      </TooltipTrigger>,
+      <TooltipContent>Waits before opening</TooltipContent>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`delayDuration` can be set per Tooltip when a specific interaction needs to feel faster or slower than the provider default.',
+      },
+    },
+  },
+}
+
+export const DisabledTrigger: Story = {
+  args: {
+    children: [
+      <TooltipTrigger asChild>
+        <span className="inline-flex" tabIndex={0}>
+          <Button variant="secondary" disabled>
+            Disabled action
+          </Button>
+        </span>
+      </TooltipTrigger>,
+      <TooltipContent>
+        This action is unavailable until setup finishes.
+      </TooltipContent>,
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Disabled buttons do not emit pointer or focus events. Wrap the disabled control in a focusable element when the tooltip needs to explain why it is disabled.',
+      },
+    },
   },
 }

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -7,7 +7,26 @@ import { cn } from '@/lib/utils'
 
 const TooltipProvider = TooltipPrimitive.Provider
 
-const Tooltip = TooltipPrimitive.Root
+export interface TooltipProps {
+  children?: React.ReactNode
+  open?: boolean
+  defaultOpen?: boolean
+  onOpenChange?: (open: boolean) => void
+  /**
+   * The duration from when the pointer enters the trigger until the tooltip
+   * opens. This overrides the TooltipProvider value.
+   * @defaultValue 700
+   */
+  delayDuration?: number
+  /**
+   * When true, the tooltip closes as the pointer leaves the trigger instead of
+   * allowing hover on the tooltip content.
+   * @defaultValue false
+   */
+  disableHoverableContent?: boolean
+}
+
+const Tooltip = (props: TooltipProps) => <TooltipPrimitive.Root {...props} />
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
@@ -29,6 +48,7 @@ const TooltipContent = React.forwardRef<
     {...props}
   />
 ))
+Tooltip.displayName = 'Tooltip'
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ export {
 } from '@/components/Select'
 export {
   Tooltip,
+  type TooltipProps,
   TooltipTrigger,
   TooltipContent,
   TooltipProvider,

--- a/type-tests/tooltip-props.ts
+++ b/type-tests/tooltip-props.ts
@@ -1,0 +1,21 @@
+import type * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import type { TooltipProps } from '@/components/Tooltip'
+
+type RadixTooltipProps = React.ComponentPropsWithoutRef<
+  typeof TooltipPrimitive.Root
+>
+
+const tooltipProps = {
+  children: null,
+  open: true,
+  defaultOpen: false,
+  onOpenChange: (open: boolean) => {
+    void open
+  },
+  delayDuration: 700,
+  disableHoverableContent: true,
+} satisfies TooltipProps
+
+const radixTooltipProps = tooltipProps satisfies RadixTooltipProps
+
+void radixTooltipProps


### PR DESCRIPTION
## Summary
- Expand Tooltip Storybook docs with practical Button, IconButton, placement, portal, delay, and disabled-trigger examples
- Switch Tooltip stories to args-based examples for cleaner Show Code output
- Add explicit TooltipProps for Storybook prop tables and guard compatibility with a type-test

## Test Plan
- pnpm type-check
- pnpm lint
- pnpm test --run