### PR TITLE
fix(storybook): type-check stories

### DIFF
--- a/src/components/ActionBar/index.stories.tsx
+++ b/src/components/ActionBar/index.stories.tsx
@@ -1,6 +1,6 @@
 import { DndContext } from '@dnd-kit/core'
 import { ActionBar } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
 
 const meta: Meta<typeof ActionBar> = {

--- a/src/components/Alert/index.stories.tsx
+++ b/src/components/Alert/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { variants } from './types'
 import { fn } from 'storybook/test'
 

--- a/src/components/AppLayout/index.stories.tsx
+++ b/src/components/AppLayout/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { AppLayout } from '.'
 import { AppLayoutProvider } from './provider'
 import { Heading } from '../Heading'

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button, ButtonProps } from './'
 import { PlusIcon as LucidePlusIcon, ChevronRight } from 'lucide-react'
 import { fn as storybookActionFn } from 'storybook/test'

--- a/src/components/CodeEditorLayout/index.stories.tsx
+++ b/src/components/CodeEditorLayout/index.stories.tsx
@@ -1,5 +1,5 @@
 import { CodeEditor, CodeEditorTabProps } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { faker } from '@faker-js/faker'
 import { Icon } from '@/components/Icon'
 import { Key } from '../KeyHint'

--- a/src/components/CodePlayground/index.stories.tsx
+++ b/src/components/CodePlayground/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@/components/Icon'
 import { CodePlayground, CodePlaygroundSnippets } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 
 const meta: Meta<typeof CodePlayground> = {

--- a/src/components/CodeSnippet/index.stories.tsx
+++ b/src/components/CodeSnippet/index.stories.tsx
@@ -1,7 +1,7 @@
 import { expect, within } from 'storybook/test'
 import { userEvent } from 'storybook/test'
 import { CodeSnippet } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
 
 const meta: Meta<typeof CodeSnippet> = {

--- a/src/components/Container/index.stories.tsx
+++ b/src/components/Container/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Container } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card, Grid } from '@/index'
 
 const meta: Meta<typeof Container> = {

--- a/src/components/ContextDropdown/index.stories.tsx
+++ b/src/components/ContextDropdown/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ContextDropdown } from '.'
 import { useModal } from '../../hooks/useModal'
 import { Button } from '../Button'

--- a/src/components/Dialog/index.stories.tsx
+++ b/src/components/Dialog/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Dialog } from '.'
 import { Button } from '../Button'
 import { Heading } from '../Heading'

--- a/src/components/DragNDrop/index.stories.tsx
+++ b/src/components/DragNDrop/index.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Draggable } from './Draggable'
 import { DragNDropArea } from './DragNDropArea'
 import { Droppable } from './Droppable'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { DragEndEvent } from '@dnd-kit/core'
 import { cn } from '@/lib/utils'
 

--- a/src/components/Dropdown/index.stories.tsx
+++ b/src/components/Dropdown/index.stories.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '../Button'
 import { Stack } from '../Stack'
 import { Icon } from '../Icon'

--- a/src/components/ExternalPill/index.stories.tsx
+++ b/src/components/ExternalPill/index.stories.tsx
@@ -1,5 +1,5 @@
 import { ExternalPill } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof ExternalPill> = {
   component: ExternalPill,

--- a/src/components/Facepile/index.stories.tsx
+++ b/src/components/Facepile/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Facepile } from '.'
 import { sizes } from '@/types'
 

--- a/src/components/GradientCircle/index.stories.tsx
+++ b/src/components/GradientCircle/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { GradientCircle } from '.'
 import { useEffect, useState } from 'react'
 

--- a/src/components/HighlightedText/index.stories.tsx
+++ b/src/components/HighlightedText/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Color, highlightBgMap, HighlightedText, mutedBgMap } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof HighlightedText> = {
   component: HighlightedText,

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Icon } from '.'
 import { customIconNames, iconNames } from './names'
 import { sizes } from '@/types'

--- a/src/components/IconButton/index.stories.tsx
+++ b/src/components/IconButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { IconButton } from './'
 import {
   PlusIcon as LucidePlusIcon,

--- a/src/components/Input/index.stories.tsx
+++ b/src/components/Input/index.stories.tsx
@@ -1,6 +1,6 @@
 import { fn } from 'storybook/test'
 import { Input, InputProps } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof Input> = {
   title: 'Components/Input',

--- a/src/components/KeyHint/index.stories.tsx
+++ b/src/components/KeyHint/index.stories.tsx
@@ -1,5 +1,5 @@
 import { KeyHint } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof KeyHint> = {
   component: KeyHint,

--- a/src/components/LanguageIndicator/index.stories.tsx
+++ b/src/components/LanguageIndicator/index.stories.tsx
@@ -1,6 +1,6 @@
 import { supportedLanguages } from '@/types'
 import { LanguageIndicator } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof LanguageIndicator> = {
   component: LanguageIndicator,

--- a/src/components/LoggedInUserMenu/index.stories.tsx
+++ b/src/components/LoggedInUserMenu/index.stories.tsx
@@ -1,5 +1,5 @@
 import { LoggedInUserMenu } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn, userEvent, within, screen, expect } from 'storybook/test'
 import { Icon } from '../Icon'
 

--- a/src/components/Logo/index.stories.tsx
+++ b/src/components/Logo/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Logo } from '.'
 
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof Logo> = {
   component: Logo,

--- a/src/components/Modal/index.stories.tsx
+++ b/src/components/Modal/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Modal } from '.'
 import { ModalProvider, Screen } from '@/context/ModalContext'
 import { useModal } from '@/hooks/useModal'

--- a/src/components/PageHeader/index.stories.tsx
+++ b/src/components/PageHeader/index.stories.tsx
@@ -1,5 +1,5 @@
 import { PageHeader } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '../Button'
 import { Icon } from '../Icon'
 

--- a/src/components/Popover/index.stories.tsx
+++ b/src/components/Popover/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Popover, PopoverContent, PopoverTrigger } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '../Button'
 
 const meta: Meta<typeof Popover> = {

--- a/src/components/PromptInput/index.stories.tsx
+++ b/src/components/PromptInput/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Attachment, PromptInput, Suggestion } from '@/components/PromptInput'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
 import { useState, useCallback, useRef } from 'react'
 

--- a/src/components/PullRequestLink/index.stories.tsx
+++ b/src/components/PullRequestLink/index.stories.tsx
@@ -1,5 +1,5 @@
 import { PullRequestLink } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof PullRequestLink> = {
   component: PullRequestLink,

--- a/src/components/ResizablePanel/index.stories.tsx
+++ b/src/components/ResizablePanel/index.stories.tsx
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { ResizablePanel } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
 

--- a/src/components/Score/index.stories.tsx
+++ b/src/components/Score/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Score } from '.'
 
 const meta: Meta<typeof Score> = {

--- a/src/components/SegmentedButton/index.stories.tsx
+++ b/src/components/SegmentedButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import {
   SegmentedButton,
   SegmentedButtonItemProps,

--- a/src/components/Separator/index.stories.tsx
+++ b/src/components/Separator/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Separator } from './'
 
 const meta: Meta<typeof Separator> = {

--- a/src/components/Skeleton/index.stories.tsx
+++ b/src/components/Skeleton/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof Skeleton> = {
   component: Skeleton,

--- a/src/components/Subnav/index.stories.tsx
+++ b/src/components/Subnav/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Subnav } from '.'
 
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Badge } from '../Badge'
 
 const meta: Meta<typeof Subnav> = {

--- a/src/components/Switch/index.stories.tsx
+++ b/src/components/Switch/index.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Switch } from '@/components/Switch'
 

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -1,6 +1,6 @@
 import { fn } from 'storybook/test'
 import { Tabs } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof Tabs> = {
   component: Tabs,

--- a/src/components/Timeline/index.stories.tsx
+++ b/src/components/Timeline/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Timeline } from '.'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '../Button'
 import {
   Code,

--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Copy, ExternalLink, PlusIcon as LucidePlusIcon } from 'lucide-react'
 import {
   Tooltip,

--- a/src/components/UserAvatar/index.stories.tsx
+++ b/src/components/UserAvatar/index.stories.tsx
@@ -1,6 +1,6 @@
 import { sizes } from '@/types'
 import { UserAvatar } from '.'
-import { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta: Meta<typeof UserAvatar> = {
   component: UserAvatar,

--- a/src/components/Wizard/index.stories.tsx
+++ b/src/components/Wizard/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Wizard } from '.'
 import { type WizardStep } from './types'
-import { StoryObj, Meta } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Badge, Heading } from '@/index'
 
 const meta: Meta<typeof Wizard> = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "target": "es2019",
     "declaration": true,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -4,15 +4,7 @@
     "incremental": false,
     "noEmit": true,
     "rootDir": ".",
-    "moduleResolution": "bundler"
   },
   "include": ["src", "type-tests"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "src/**/*.stories.tsx",
-    "src/**/*.stories.mdx",
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx"
-  ]
+  "exclude": ["node_modules", "dist"],
 }


### PR DESCRIPTION
## Summary
- Use bundler module resolution so Storybook package exports resolve in TypeScript
- Include stories and tests in the CI typecheck config
- Convert Storybook Meta/StoryObj imports to type-only imports

## Test Plan
- pnpm type-check
- pnpm lint
- pnpm test