### PR TITLE
feat(package): stabilize CSS export

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.9.1",
   "packageManager": "pnpm@11.4.0",
   "description": "Speakeasy's design system Moonshine",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "main": "dist/moonshine.cjs.js",
   "module": "dist/moonshine.es.js",
   "types": "dist/index.d.ts",
@@ -13,10 +15,7 @@
       "require": "./dist/moonshine.cjs.js",
       "import": "./dist/moonshine.es.js"
     },
-    "./moonshine.css": {
-      "require": "./dist/style.css",
-      "import": "./dist/style.css"
-    },
+    "./moonshine.css": "./dist/moonshine.css",
     "./src/global.css": {
       "require": "./src/global.css",
       "import": "./src/global.css"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -37,6 +37,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: packageName,
       fileName: (format) => `${packageName}.${format}.js`,
+      cssFileName: packageName,
       formats: ['es'],
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- Update the public ./moonshine.css export to point at the built CSS artifact, dist/moonshine.css
- Pin Vite's library CSS filename to moonshine so the export map no longer depends on an implicit tool default
- Mark CSS files as package side effects so consumer bundlers preserve Moonshine styles during tree-shaking

## Root Cause
- The Vite 8 upgrade changed the library CSS build artifact from dist/style.css to dist/moonshine.css.
- Moonshine's package export map still resolved @speakeasy-api/moonshine/moonshine.css to dist/style.css, so consumers could import the documented public path but their bundler could not find the target file.
- The package also declared sideEffects: false despite importing CSS, which made the CSS contract brittle for consumer bundlers that tree-shake side-effect imports.

## Test Plan
- pnpm test --run
- pnpm type-check
- pnpm lint
- pnpm build
- node export metadata check confirmed ./moonshine.css resolves to an existing dist/moonshine.css file and CSS sideEffects are declared