### PR TITLE
chore: add cubic config

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+
+# cubic.yaml
+# This file configures AI review behavior, ignore patterns, PR descriptions, and custom rules.
+# Place this file in your repository root to version-control your AI review settings.
+# Settings defined here take precedence over UI-configured settings.
+# See https://docs.cubic.dev/configure/cubic-yaml for documentation.
+
+version: 1
+reviews:
+  enabled: true
+  sensitivity: high
+  incremental_commits: true
+  check_drafts: false
+  architecture_diagrams: false
+  external_contributors_require_manual_review: true
+  resolve_threads_when_addressed: true
+  merge_confidence_summary: true
+  auto_approve_behavior: disabled
+  auto_approve: disabled
+  ignore:
+    files:
+      - '**/*.svg'
+      - docs/
+      - tests/visual/storybook.visual.spec.ts-snapshots/
+    pr_labels:
+      - wip
+      - skip-review
+  custom_rules:
+    - name: Flag Security Vulnerabilities
+      description: |-
+        Scan for security flaws: hardcoded secrets, SQL injection, XSS, weak auth, exposed data, poor crypto, unsafe deserialization, insecure HTTP calls in production, and more. Ensure all network requests use HTTPS/TLS. Identify attack vectors and security violations to maintain robust defenses.
+        Insecure Direct Object Reference (IDOR) vulnerabilities are mitigated by explicitly scoping all queries to organization or project ids. Ensure this is the case whenever SQLc queries are added or updated.
+pr_descriptions:
+  generate: true
+  cubic_review_link: true
+issues:
+  fix_with_cubic_buttons: true
+  pr_comment_fixes: true
+  fix_commits_to_pr: true


### PR DESCRIPTION
## Summary
- Adds `cubic.yaml` to the repo root to configure AI-powered code review behavior
- Enables high-sensitivity reviews with incremental commit checks, ignoring SVGs, dist, docs, and snapshot files
- Configures custom rule to flag security vulnerabilities and enables PR description generation

## Test Plan
- [x] Verify cubic.yaml is valid by checking schema at https://cubic.dev/schema/cubic-repository-config.schema.json
- [ ] Confirm Cubic picks up the config on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cubic.yaml` to configure Cubic code review. Enables high-sensitivity, incremental reviews, auto PR descriptions, and label-based skip rules while ignoring non-source files.

- New Features
  - High-sensitivity reviews with incremental commit checks; drafts not checked; merge confidence summary enabled.
  - Auto-approve disabled; external contributors require manual review; addressed threads auto-resolve.
  - Ignore: `**/*.svg`, `docs/`, and `tests/visual/storybook.visual.spec.ts-snapshots/`; skip PRs labeled `wip` or `skip-review`.
  - Security rule flags secrets, SQLi/XSS, enforces HTTPS, and requires org/project scoping to prevent IDOR; PR descriptions include a Cubic link with quick-fix buttons enabled.

<sup>Written for commit ee874f7932895500e6c2bbf266a79744f02fea4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/moonshine/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

