### PR TITLE
chore(deps): upgrade faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "^10.4.0",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^14.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@faker-js/faker':
-        specifier: ^9.2.0
-        version: 9.9.0
+        specifier: ^10.4.0
+        version: 10.4.0
       '@semantic-release/commit-analyzer':
         specifier: ^13.0.0
         version: 13.0.1(semantic-release@24.2.9(typescript@5.9.3))
@@ -652,9 +652,9 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@faker-js/faker@9.9.0':
-    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
-    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -5301,7 +5301,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@faker-js/faker@9.9.0': {}
+  '@faker-js/faker@10.4.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade @faker-js/faker from 9.9.0 to 10.4.0.
- Refresh pnpm lockfile for the new faker major.
- Keep Storybook source unchanged because existing faker usage is compatible.

## Test Plan
- [x] pnpm test -- --run
- [x] pnpm type-check
- [x] pnpm build-storybook
- [x] pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `@faker-js/faker` to `10.4.0` and refreshed the lockfile. Storybook usage stays compatible; no code changes needed.

- **Migration**
  - `@faker-js/faker@10.4.0` requires Node >=20.19 and npm >=10. Update local/CI runtimes if needed.
  - After upgrading runtimes, run pnpm install.

<sup>Written for commit 2a3d79c64634a335c146ee0baac11c55f412b647. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/moonshine/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

