### PR TITLE
ci: bump node20 actions to node24 runtime

### DIFF
--- a/.github/workflows/conventional-commit-checker.yml
+++ b/.github/workflows/conventional-commit-checker.yml
@@ -13,6 +13,6 @@ jobs:
     name: Check Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/published-test.yml
+++ b/.github/workflows/published-test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## What

Bump two GitHub Actions still running the deprecated **node20** runtime to **node24**:

| Action | Before | After |
|---|---|---|
| `pnpm/action-setup` | `@v4` | `@v6` |
| `amannn/action-semantic-pull-request` | `@v5` | `@v6` |

## Why

CI emits node20 runtime deprecation warnings. These two were the only actions still on node20 — `actions/checkout@v6`, `actions/setup-node@v6`, and `cycjimmy/semantic-release-action` (v6.0.0) already run node24.

## Notes

- `pnpm/action-setup` v5+ resolves the pnpm version from `packageManager` in `package.json` (`pnpm@11.4.0`, already present) — no `version` input needed.
- Floating major tags kept, consistent with existing workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade remaining CI actions from the deprecated node20 runtime to node24 to remove deprecation warnings and keep workflows consistent.

- **Dependencies**
  - `pnpm/action-setup`: `@v4` ➝ `@v6` (uses `packageManager` in `package.json`; no `version` input needed)
  - `amannn/action-semantic-pull-request`: `@v5` ➝ `@v6`

<sup>Written for commit dc77521b4810594b4111d3f6078564dcfd6d5d49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/moonshine/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

