### PR TITLE
fix(table): sort enrolled employees first

### DIFF
--- a/src/components/Table/sorting.test.ts
+++ b/src/components/Table/sorting.test.ts
@@ -70,12 +70,39 @@ describe("Table sorting helpers", () => {
   it("compares strings, numbers, booleans, dates, and nulls consistently", () => {
     expect(compareSortValues("a", "b")).toBeLessThan(0);
     expect(compareSortValues(2, 1)).toBeGreaterThan(0);
-    expect(compareSortValues(false, true)).toBeLessThan(0);
+    expect(compareSortValues(true, false)).toBeLessThan(0);
+    expect(compareSortValues(false, true)).toBeGreaterThan(0);
     expect(
       compareSortValues(new Date("2026-05-01"), new Date("2026-05-02")),
     ).toBeLessThan(0);
     expect(compareSortValues(null, "a")).toBeGreaterThan(0);
     expect(compareSortValues(undefined, null)).toBe(0);
+  });
+
+  it("sortRows puts enrolled employees first in ascending boolean order", () => {
+    type Employee = { name: string; enrolled: boolean };
+
+    const employees: Employee[] = [
+      { name: "Not enrolled", enrolled: false },
+      { name: "Enrolled", enrolled: true },
+    ];
+    const enrolledColumn: Column<Employee> = {
+      key: "enrolled",
+      header: "Role",
+      sortable: true,
+      sortValue: (employee) => employee.enrolled,
+    };
+
+    expect(
+      sortRows(employees, enrolledColumn, "asc").map(
+        (employee) => employee.name,
+      ),
+    ).toEqual(["Enrolled", "Not enrolled"]);
+    expect(
+      sortRows(employees, enrolledColumn, "desc").map(
+        (employee) => employee.name,
+      ),
+    ).toEqual(["Not enrolled", "Enrolled"]);
   });
 
   it("sortRows keeps null values last in both directions", () => {

--- a/src/components/Table/sorting.ts
+++ b/src/components/Table/sorting.ts
@@ -36,6 +36,11 @@ export function compareSortValues(a: SortValue, b: SortValue): number {
   const normalizedA = normalizeSortValue(a);
   const normalizedB = normalizeSortValue(b);
 
+  if (typeof normalizedA === "boolean" && typeof normalizedB === "boolean") {
+    if (normalizedA === normalizedB) return 0;
+    return normalizedA ? -1 : 1;
+  }
+
   if (typeof normalizedA === "string" && typeof normalizedB === "string") {
     return normalizedA.localeCompare(normalizedB, undefined, {
       numeric: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- order `true` boolean sort values before `false` in ascending table sorts
- preserve the inverse ordering for descending sorts
- add regression coverage for enrolled versus unenrolled employees

## Test plan
- [x] `pnpm test -- --run src/components/Table/sorting.test.ts` (68 tests passed)
- [x] `pnpm type-check`
- [x] `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [S-503](https://linear.app/speakeasy/issue/S-503/fix-sort-employees-in-td-class-tablecell-1bgl-in-speakeasy)

<div><a href="https://cursor.com/agents/bc-5444ab8f-3e72-4a3a-a49a-75cde878cc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5444ab8f-3e72-4a3a-a49a-75cde878cc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

