### PR TITLE
fix(Button): prevent implicit form submissions

### DIFF
--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { Button } from "./";
 
 describe("Button", () => {
@@ -19,5 +19,42 @@ describe("Button", () => {
     expect(text.tagName).toBe("SPAN");
     expect(text).toHaveClass("text-trim-cap");
     expect(text).not.toHaveClass("relative"); // button wrapper has 'relative', text span does not
+  });
+
+  it("defaults to type button so it does not submit a parent form", () => {
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Button>Discover</Button>
+      </form>,
+    );
+
+    const button = screen.getByRole("button", { name: "Discover" });
+    expect(button).toHaveAttribute("type", "button");
+
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit submit type", () => {
+    render(<Button type="submit">Authorize</Button>);
+
+    expect(screen.getByRole("button", { name: "Authorize" })).toHaveAttribute(
+      "type",
+      "submit",
+    );
+  });
+
+  it("does not pass the default type to an asChild element", () => {
+    render(
+      <Button asChild>
+        <a href="/discover">Discover</a>
+      </Button>,
+    );
+
+    expect(screen.getByRole("link", { name: "Discover" })).not.toHaveAttribute(
+      "type",
+    );
   });
 });

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -213,6 +213,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       context = "product",
       asChild = false,
       className,
+      type,
       onMouseEnter,
       onMouseLeave,
       onMouseDown,
@@ -486,6 +487,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         onMouseMove={handleMouseMove}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
+        {...(!asChild ? { type: type ?? "button" } : {})}
         {...(asChild ? { isBrandVariant } : {})}
         {...props}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- default Moonshine buttons to `type="button"`, preventing incidental controls such as Discover from submitting their parent form and triggering scope validation
- preserve explicit submit/reset types
- avoid forwarding the default type through `asChild`
- add regression coverage for buttons rendered inside forms

Linear: AGE-3026

## Testing
- `pnpm test --run` (70 tests passed)
- `pnpm type-check`
- `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3026](https://linear.app/speakeasy/issue/AGE-3026/fix-make-sure-discover-button-doesnt-require-scope-to-authorize-div-in)

<div><a href="https://cursor.com/agents/bc-64480c82-5106-4349-80c4-a0dcaf3b7e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64480c82-5106-4349-80c4-a0dcaf3b7e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

